### PR TITLE
feat: 사용자 정보 추가 및 조회 응답 데이터 구현

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/leave/entity/UserLeave.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/entity/UserLeave.java
@@ -4,17 +4,21 @@ import com.bmilab.backend.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -29,8 +33,9 @@ public class UserLeave {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
+    @OneToOne(optional = false)
+    @JoinColumn(name = "user_id", updatable = false, nullable = false, unique = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Column(name = "annual_leave_count", nullable = false)

--- a/src/main/java/com/bmilab/backend/domain/user/dto/query/UserDetailQueryResult.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/query/UserDetailQueryResult.java
@@ -1,0 +1,12 @@
+package com.bmilab.backend.domain.user.dto.query;
+
+import com.bmilab.backend.domain.leave.entity.UserLeave;
+import com.bmilab.backend.domain.user.entity.User;
+import com.bmilab.backend.domain.user.entity.UserInfo;
+
+public record UserDetailQueryResult(
+        User user,
+        UserLeave userLeave,
+        UserInfo userInfo
+) {
+}

--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/RegisterUserRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/RegisterUserRequest.java
@@ -1,11 +1,19 @@
 package com.bmilab.backend.domain.user.dto.request;
 
+import com.bmilab.backend.domain.project.enums.ProjectCategory;
+import java.time.LocalDate;
+import java.util.List;
+
 public record RegisterUserRequest(
         String name,
         String email,
         String password,
         String department,
         Double annualLeaveCount,
-        Double usedLeaveCount
+        Double usedLeaveCount,
+        List<ProjectCategory> categories,
+        String seatNumber,
+        String phoneNumber,
+        LocalDate joinedAt
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/user/dto/response/CurrentUserDetail.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/response/CurrentUserDetail.java
@@ -3,6 +3,7 @@ package com.bmilab.backend.domain.user.dto.response;
 import com.bmilab.backend.domain.leave.dto.response.LeaveDetail;
 import com.bmilab.backend.domain.leave.entity.Leave;
 import com.bmilab.backend.domain.leave.entity.UserLeave;
+import com.bmilab.backend.domain.user.dto.query.UserDetailQueryResult;
 import com.bmilab.backend.domain.user.entity.User;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -13,10 +14,10 @@ public record CurrentUserDetail(
         UserDetail user,
         List<LeaveDetail> leaves
 ) {
-    public static CurrentUserDetail from(User user, UserLeave userLeave, List<Leave> leaves) {
+    public static CurrentUserDetail from(UserDetailQueryResult queryResult, List<Leave> leaves) {
         return CurrentUserDetail
                 .builder()
-                .user(UserDetail.from(user, userLeave))
+                .user(UserDetail.from(queryResult))
                 .leaves(
                         leaves.stream()
                                 .map(LeaveDetail::from)

--- a/src/main/java/com/bmilab/backend/domain/user/dto/response/UserDetail.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/response/UserDetail.java
@@ -1,9 +1,14 @@
 package com.bmilab.backend.domain.user.dto.response;
 
 import com.bmilab.backend.domain.leave.entity.UserLeave;
+import com.bmilab.backend.domain.project.enums.ProjectCategory;
+import com.bmilab.backend.domain.user.dto.query.UserDetailQueryResult;
 import com.bmilab.backend.domain.user.entity.User;
+import com.bmilab.backend.domain.user.entity.UserInfo;
 import com.bmilab.backend.domain.user.enums.Role;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -13,12 +18,19 @@ public record UserDetail(
         String name,
         String department,
         Role role,
-        String comment,
         Double annualLeaveCount,
         Double usedLeaveCount,
-        LocalDateTime joinedAt
+        List<ProjectCategory> categories,
+        String seatNumber,
+        String phoneNumber,
+        String comment,
+        LocalDate joinedAt
 ) {
-    public static UserDetail from(User user, UserLeave userLeave) {
+    public static UserDetail from(UserDetailQueryResult queryResult) {
+        User user = queryResult.user();
+        UserLeave userLeave = queryResult.userLeave();
+        UserInfo userInfo = queryResult.userInfo();
+
         return UserDetail
                 .builder()
                 .userId(user.getId())
@@ -26,10 +38,18 @@ public record UserDetail(
                 .name(user.getName())
                 .department(user.getDepartment())
                 .role(user.getRole())
-                .comment(user.getComment())
+                .comment(userInfo.getComment())
                 .annualLeaveCount(userLeave.getAnnualLeaveCount())
                 .usedLeaveCount(userLeave.getUsedLeaveCount())
-                .joinedAt(user.getCreatedAt())
+                .categories(
+                        Arrays.stream(userInfo.getCategory().split(","))
+                                .map(ProjectCategory::valueOf)
+                                .toList()
+                )
+                .seatNumber(userInfo.getSeatNumber())
+                .phoneNumber(userInfo.getPhoneNumber())
+                .comment(userInfo.getComment())
+                .joinedAt(userInfo.getJoinedAt())
                 .build();
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/user/entity/UserInfo.java
+++ b/src/main/java/com/bmilab/backend/domain/user/entity/UserInfo.java
@@ -3,54 +3,53 @@ package com.bmilab.backend.domain.user.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import com.bmilab.backend.domain.user.enums.Role;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
-@Table(name = "users")
+@Table(name = "user_info")
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-public class User {
+public class UserInfo {
+
     @Id
-    @Column(name = "user_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
-    private String email;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true, nullable = false)
+    private User user;
 
     @Column(nullable = false)
-    private String password;
+    private String category;
 
-    @Column(nullable = false)
-    private String name;
+    @Column(name = "seat_num")
+    private String seatNumber;
 
-    @Column(name = "profile_image_url", columnDefinition = "TEXT")
-    private String profileImageUrl;
+    @Column(name = "phone_number")
+    private String phoneNumber;
 
-    @Column(nullable = false)
-    private String department;
+    @Column(name = "joined_at")
+    private LocalDate joinedAt;
 
-    @Enumerated(EnumType.STRING)
-    private Role role;
+    private String comment;
 
-    @CreatedDate
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
+    public void updateComment(String comment) {
+        this.comment = comment;
+    }
 }

--- a/src/main/java/com/bmilab/backend/domain/user/repository/UserInfoRepository.java
+++ b/src/main/java/com/bmilab/backend/domain/user/repository/UserInfoRepository.java
@@ -1,0 +1,7 @@
+package com.bmilab.backend.domain.user.repository;
+
+import com.bmilab.backend.domain.user.entity.UserInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserInfoRepository extends JpaRepository<UserInfo, Long> {
+}

--- a/src/main/java/com/bmilab/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/bmilab/backend/domain/user/repository/UserRepository.java
@@ -1,16 +1,15 @@
 package com.bmilab.backend.domain.user.repository;
 
-import com.amazonaws.services.s3.model.RequestPaymentConfiguration.Payer;
 import com.bmilab.backend.domain.user.entity.User;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
     Optional<User> findByEmail(String email);
+
     boolean existsByName(String name);
 
     @Query("select u from User u where u.id in :ids")

--- a/src/main/java/com/bmilab/backend/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/bmilab/backend/domain/user/repository/UserRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.bmilab.backend.domain.user.repository;
+
+import com.bmilab.backend.domain.user.dto.query.UserDetailQueryResult;
+import java.util.Optional;
+
+public interface UserRepositoryCustom {
+    Optional<UserDetailQueryResult> findUserDetailsById(Long userId);
+}

--- a/src/main/java/com/bmilab/backend/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/bmilab/backend/domain/user/repository/UserRepositoryCustomImpl.java
@@ -1,0 +1,37 @@
+package com.bmilab.backend.domain.user.repository;
+
+import com.bmilab.backend.domain.leave.entity.QUserLeave;
+import com.bmilab.backend.domain.user.dto.query.UserDetailQueryResult;
+import com.bmilab.backend.domain.user.entity.QUser;
+import com.bmilab.backend.domain.user.entity.QUserInfo;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserRepositoryCustomImpl implements UserRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<UserDetailQueryResult> findUserDetailsById(Long userId) {
+        QUser user = QUser.user;
+        QUserLeave userLeave = QUserLeave.userLeave;
+        QUserInfo userInfo = QUserInfo.userInfo;
+
+        UserDetailQueryResult result = queryFactory
+                .select(Projections.constructor(
+                        UserDetailQueryResult.class,
+                        user,
+                        userLeave,
+                        userInfo
+                ))
+                .from(user)
+                .innerJoin(userInfo).on(userInfo.user.eq(user))
+                .innerJoin(userLeave).on(userLeave.user.eq(user))
+                .where(user.id.eq(userId))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+}

--- a/src/main/java/com/bmilab/backend/domain/user/service/AuthService.java
+++ b/src/main/java/com/bmilab/backend/domain/user/service/AuthService.java
@@ -2,12 +2,15 @@ package com.bmilab.backend.domain.user.service;
 
 import com.bmilab.backend.domain.leave.entity.UserLeave;
 import com.bmilab.backend.domain.leave.repository.UserLeaveRepository;
+import com.bmilab.backend.domain.project.enums.ProjectCategory;
 import com.bmilab.backend.domain.user.dto.request.LoginRequest;
 import com.bmilab.backend.domain.user.dto.request.RegisterUserRequest;
 import com.bmilab.backend.domain.user.dto.response.LoginResponse;
 import com.bmilab.backend.domain.user.entity.User;
+import com.bmilab.backend.domain.user.entity.UserInfo;
 import com.bmilab.backend.domain.user.enums.Role;
 import com.bmilab.backend.domain.user.exception.UserErrorCode;
+import com.bmilab.backend.domain.user.repository.UserInfoRepository;
 import com.bmilab.backend.domain.user.repository.UserRepository;
 import com.bmilab.backend.global.exception.ApiException;
 import com.bmilab.backend.global.jwt.TokenProvider;
@@ -26,6 +29,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
     private final UserLeaveRepository userLeaveRepository;
+    private final UserInfoRepository userInfoRepository;
 
     public LoginResponse login(@RequestBody LoginRequest request) {
         User user = userRepository.findByEmail(request.email())
@@ -34,6 +38,10 @@ public class AuthService {
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             throw new ApiException(UserErrorCode.PASSWORD_MISMATCH);
         }
+
+//        if (!request.password().equals(user.getPassword())) {
+//            throw new ApiException(UserErrorCode.PASSWORD_MISMATCH);
+//        }
 
         String accessToken = tokenProvider.generateToken(user, Duration.ofDays(30));
 
@@ -59,5 +67,22 @@ public class AuthService {
                 .build();
 
         userLeaveRepository.save(userLeave);
+
+        UserInfo userInfo = UserInfo.builder()
+                .user(user)
+                .seatNumber(request.seatNumber())
+                .phoneNumber(request.phoneNumber())
+                .joinedAt(request.joinedAt())
+                .category(
+                        String.join(",",
+                                request.categories()
+                                        .stream()
+                                        .map(ProjectCategory::name)
+                                        .toList()
+                        )
+                )
+                .build();
+
+        userInfoRepository.save(userInfo);
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/bmilab/backend/domain/user/service/UserService.java
@@ -1,17 +1,16 @@
 package com.bmilab.backend.domain.user.service;
 
 import com.bmilab.backend.domain.leave.entity.Leave;
-import com.bmilab.backend.domain.leave.entity.UserLeave;
-import com.bmilab.backend.domain.leave.exception.LeaveErrorCode;
 import com.bmilab.backend.domain.leave.repository.LeaveRepository;
 import com.bmilab.backend.domain.leave.repository.UserLeaveRepository;
+import com.bmilab.backend.domain.user.dto.query.UserDetailQueryResult;
 import com.bmilab.backend.domain.user.dto.request.UpdateUserRequest;
 import com.bmilab.backend.domain.user.dto.response.CurrentUserDetail;
 import com.bmilab.backend.domain.user.dto.response.UserDetail;
 import com.bmilab.backend.domain.user.dto.response.UserSummary;
 import com.bmilab.backend.domain.user.dto.response.UserFindAllResponse;
-import com.bmilab.backend.domain.user.entity.User;
 import com.bmilab.backend.domain.user.exception.UserErrorCode;
+import com.bmilab.backend.domain.user.repository.UserInfoRepository;
 import com.bmilab.backend.domain.user.repository.UserRepository;
 import com.bmilab.backend.global.exception.ApiException;
 import java.util.List;
@@ -29,6 +28,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserLeaveRepository userLeaveRepository;
     private final LeaveRepository leaveRepository;
+    private final UserInfoRepository userInfoRepository;
 
     public UserFindAllResponse getAllUsers(int pageNo, String criteria) {
         PageRequest pageRequest = PageRequest.of(pageNo, 10, Sort.by(Direction.DESC, criteria));
@@ -42,36 +42,28 @@ public class UserService {
     }
 
     public UserDetail getUserById(long userId) {
-        User user = userRepository.findById(userId)
+        UserDetailQueryResult result = userRepository.findUserDetailsById(userId)
                 .orElseThrow(() -> new ApiException(UserErrorCode.USER_NOT_FOUND));
 
-        UserLeave userLeave = userLeaveRepository.findByUserId(userId)
-                .orElseThrow(() -> new ApiException(LeaveErrorCode.USER_LEAVE_NOT_FOUND));
-
-        return UserDetail.from(user, userLeave);
+        return UserDetail.from(result);
     }
 
 
     public CurrentUserDetail getCurrentUser(Long userId) {
-        User user = userRepository.findById(userId)
+        UserDetailQueryResult result = userRepository.findUserDetailsById(userId)
                 .orElseThrow(() -> new ApiException(UserErrorCode.USER_NOT_FOUND));
-
-        UserLeave userLeave = userLeaveRepository.findByUserId(userId)
-                .orElseThrow(() -> new ApiException(LeaveErrorCode.USER_LEAVE_NOT_FOUND));
-
         List<Leave> leaves = leaveRepository.findAllByUserId(userId);
 
-        return CurrentUserDetail.from(user, userLeave, leaves);
+        return CurrentUserDetail.from(result, leaves);
     }
 
     @Transactional
     public void updateUserById(Long userId, UpdateUserRequest request) {
-        User user = userRepository.findById(userId)
+        UserDetailQueryResult result = userRepository.findUserDetailsById(userId)
                 .orElseThrow(() -> new ApiException(UserErrorCode.USER_NOT_FOUND));
-        UserLeave userLeave = userLeaveRepository.findByUserId(userId)
-                .orElseThrow(() -> new ApiException(LeaveErrorCode.USER_LEAVE_NOT_FOUND));
 
-        user.updateComment(request.comment());
-        userLeave.updateAnnualLeaveCount(request.annualLeaveCount());
+
+        result.userInfo().updateComment(request.comment());
+        result.userLeave().updateAnnualLeaveCount(request.annualLeaveCount());
     }
 }


### PR DESCRIPTION
- User 테이블에 있던 사용자의 부가 정보들을 UserInfo 테이블로 분리하였습니다.
- 3개의 테이블을 한 번에 조회해야할 때 QueryDSL을 이용하여 조회 수를 줄였습니다.

[GET] /users/{userId} 조회 결과
<img width="1402" alt="스크린샷 2025-04-25 오전 12 07 05" src="https://github.com/user-attachments/assets/db67fa57-2102-46ed-bde4-10a3bdbb08b1" />
