### PR TITLE
Refactor/#11 /users/search 및 /projects API 필터링 로직 개선

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/project/controller/ProjectApi.java
+++ b/src/main/java/com/bmilab/backend/domain/project/controller/ProjectApi.java
@@ -171,6 +171,8 @@ public interface ProjectApi {
             @RequestParam(required = false) Long leaderId,
             @RequestParam(required = false) ProjectCategory category,
             @RequestParam(required = false) ProjectStatus status,
+            @RequestParam(required = false) String pi,
+            @RequestParam(required = false) String practicalProfessor,
             @PageableDefault(sort = "createdAt", direction = Direction.DESC) @ParameterObject Pageable pageable
     );
 

--- a/src/main/java/com/bmilab/backend/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/bmilab/backend/domain/project/controller/ProjectController.java
@@ -107,11 +107,14 @@ public class ProjectController implements ProjectApi {
             @RequestParam(required = false) Long leaderId,
             @RequestParam(required = false) ProjectCategory category,
             @RequestParam(required = false) ProjectStatus status,
+            @RequestParam(required = false) String pi,
+            @RequestParam(required = false) String practicalProfessor,
             @PageableDefault(size = 10, sort = "createdAt", direction = Direction.DESC) @ParameterObject Pageable pageable
     ) {
 
         return ResponseEntity.ok(
-                projectService.getAllProjects(pageable, search, ProjectFilterCondition.of(leaderId, category, status))
+                projectService.getAllProjects(pageable, search, ProjectFilterCondition.of(leaderId, category, status,
+                        pi, practicalProfessor))
         );
     }
 

--- a/src/main/java/com/bmilab/backend/domain/project/dto/condition/ProjectFilterCondition.java
+++ b/src/main/java/com/bmilab/backend/domain/project/dto/condition/ProjectFilterCondition.java
@@ -6,9 +6,11 @@ import com.bmilab.backend.domain.project.enums.ProjectStatus;
 public record ProjectFilterCondition(
         Long leaderId,
         ProjectCategory category,
-        ProjectStatus status
+        ProjectStatus status,
+        String pi,
+        String practicalProfessor
 ) {
-    public static ProjectFilterCondition of(Long leaderId, ProjectCategory category, ProjectStatus status) {
-        return new ProjectFilterCondition(leaderId, category, status);
+    public static ProjectFilterCondition of(Long leaderId, ProjectCategory category, ProjectStatus status, String pi, String practicalProfessor) {
+        return new ProjectFilterCondition(leaderId, category, status, pi, practicalProfessor);
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/bmilab/backend/domain/user/repository/UserRepository.java
@@ -19,4 +19,6 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
             + "OR u.email LIKE CONCAT('%', :name, '%') "
             + "OR u.department LIKE CONCAT('%', :name, '%')")
     List<User> searchUsersByKeyword (String name);
+
+    List<User> findTop10ByOrderByIdDesc();
 }

--- a/src/main/java/com/bmilab/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/bmilab/backend/domain/user/service/UserService.java
@@ -134,8 +134,15 @@ public class UserService {
     }
 
     public SearchUserResponse searchUsers(String keyword) {
-        List<User> users = userRepository.searchUsersByKeyword(keyword);
+        List<User> users;
+
+        if (keyword == null || keyword.trim().isEmpty()) {
+            users = userRepository.findTop10ByOrderByIdDesc();
+        } else {
+            users = userRepository.searchUsersByKeyword(keyword);
+        }
 
         return SearchUserResponse.of(users);
     }
 }
+


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #11 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- GET /users/search: 검색어가 없을 경우 전체 유저 목록 응답하도록 로직 수정
-  GET /projects: 쿼리 파라미터에 PI, 실무교수 키워드 필터 기능 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
