### PR TITLE
feat: 프로젝트 목록 조회에 PI 및 실무교수 키워드 필터 기능 추가

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/project/dto/condition/ProjectFilterCondition.java
+++ b/src/main/java/com/bmilab/backend/domain/project/dto/condition/ProjectFilterCondition.java
@@ -6,9 +6,11 @@ import com.bmilab.backend.domain.project.enums.ProjectStatus;
 public record ProjectFilterCondition(
         Long leaderId,
         ProjectCategory category,
-        ProjectStatus status
+        ProjectStatus status,
+        String pi,
+        String practicalProfessor
 ) {
-    public static ProjectFilterCondition of(Long leaderId, ProjectCategory category, ProjectStatus status) {
-        return new ProjectFilterCondition(leaderId, category, status);
+    public static ProjectFilterCondition of(Long leaderId, ProjectCategory category, ProjectStatus status, String pi, String practicalProfessor) {
+        return new ProjectFilterCondition(leaderId, category, status, pi, practicalProfessor);
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/project/repository/ProjectRepositoryCustomImpl.java
+++ b/src/main/java/com/bmilab/backend/domain/project/repository/ProjectRepositoryCustomImpl.java
@@ -45,6 +45,11 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
 
         BooleanExpression titleContains = keyword != null ? project.title.containsIgnoreCase(keyword) : null;
 
+        BooleanExpression piContains = condition.pi() != null ? project.pi.containsIgnoreCase(condition.pi()) : null;
+
+        BooleanExpression practicalProfessorContains = condition.practicalProfessor() != null ?
+                project.practicalProfessor.containsIgnoreCase(condition.practicalProfessor()) : null;
+
         BooleanExpression leaderNameContains = keyword != null
                 ? JPAExpressions.selectOne()
                 .from(participant)
@@ -91,7 +96,7 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
                 ))
                 .from(project)
                 .where(
-                        Expressions.anyOf(titleContains, leaderNameContains),
+                        Expressions.anyOf(titleContains, leaderNameContains, piContains, practicalProfessorContains),
                         statusFilter,
                         categoryFilter,
                         leaderFilter

--- a/src/main/java/com/bmilab/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/bmilab/backend/domain/user/repository/UserRepository.java
@@ -15,8 +15,10 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     @Query("select u from User u where u.id in :ids")
     List<User> findAllByIds(Set<Long> ids);
 
-    @Query("SELECT u FROM User u WHERE u.name LIKE CONCAT('%', :name, '%') "
+    @Query("SELECT u FROM User u WHERE :name IS NULL "
+            + "OR :name = '' "
+            + "OR u.name LIKE CONCAT('%', :name, '%') "
             + "OR u.email LIKE CONCAT('%', :name, '%') "
             + "OR u.department LIKE CONCAT('%', :name, '%')")
-    List<User> searchUsersByKeyword (String name);
+    List<User> searchUsersByKeyword(String name);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#11 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- GET /users/search: 검색어가 없을 경우 전체 유저 목록 응답하도록 로직 수정
- GET /projects: 쿼리 파라미터에 PI, 실무교수 키워드 필터 기능 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
