### PR TITLE
feat: BaseTimeEntity 도입 - created_at과 updated_at 관리 통합

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/file/entity/FileInformation.java
+++ b/src/main/java/com/bmilab/backend/domain/file/entity/FileInformation.java
@@ -1,13 +1,11 @@
 package com.bmilab.backend.domain.file.entity;
 
 import com.bmilab.backend.domain.file.enums.FileDomainType;
+import com.bmilab.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
@@ -16,7 +14,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "files")
@@ -24,8 +21,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-public class FileInformation {
+public class FileInformation extends BaseTimeEntity {
     @Id
     private UUID id;
 

--- a/src/main/java/com/bmilab/backend/domain/leave/entity/Leave.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/entity/Leave.java
@@ -3,9 +3,9 @@ package com.bmilab.backend.domain.leave.entity;
 import com.bmilab.backend.domain.leave.enums.LeaveStatus;
 import com.bmilab.backend.domain.leave.enums.LeaveType;
 import com.bmilab.backend.domain.user.entity.User;
+import com.bmilab.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -25,7 +25,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "leaves")
@@ -33,8 +32,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-public class Leave {
+public class Leave extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "leave_id")

--- a/src/main/java/com/bmilab/backend/domain/leave/entity/UserLeave.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/entity/UserLeave.java
@@ -1,15 +1,13 @@
 package com.bmilab.backend.domain.leave.entity;
 
 import com.bmilab.backend.domain.user.entity.User;
+import com.bmilab.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -19,7 +17,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "user_leaves")
@@ -27,8 +24,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-public class UserLeave {
+public class UserLeave extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/bmilab/backend/domain/project/entity/Project.java
+++ b/src/main/java/com/bmilab/backend/domain/project/entity/Project.java
@@ -4,9 +4,9 @@ import com.bmilab.backend.domain.project.enums.ProjectCategory;
 import com.bmilab.backend.domain.project.enums.ProjectStatus;
 import com.bmilab.backend.domain.user.entity.User;
 import com.bmilab.backend.domain.user.enums.Role;
+import com.bmilab.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -15,15 +15,11 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "projects")
@@ -31,8 +27,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-public class Project {
+public class Project extends BaseTimeEntity {
     @Id
     @Column(name = "project_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -72,14 +67,6 @@ public class Project {
 
     @Column(name = "drb_id")
     private String drbId;
-
-    @CreatedDate
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
 
     @Builder.Default
     @Column(name = "is_private", columnDefinition = "TINYINT(1)")

--- a/src/main/java/com/bmilab/backend/domain/project/entity/ProjectFile.java
+++ b/src/main/java/com/bmilab/backend/domain/project/entity/ProjectFile.java
@@ -2,9 +2,9 @@ package com.bmilab.backend.domain.project.entity;
 
 import com.bmilab.backend.domain.file.entity.FileInformation;
 import com.bmilab.backend.domain.project.enums.ProjectFileType;
+import com.bmilab.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -20,7 +20,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "project_files")
@@ -28,8 +27,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-public class ProjectFile {
+public class ProjectFile extends BaseTimeEntity {
     @Id
     @Column(name = "project_file_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/bmilab/backend/domain/project/entity/ProjectParticipant.java
+++ b/src/main/java/com/bmilab/backend/domain/project/entity/ProjectParticipant.java
@@ -2,10 +2,10 @@ package com.bmilab.backend.domain.project.entity;
 
 import com.bmilab.backend.domain.project.enums.ProjectParticipantType;
 import com.bmilab.backend.domain.user.entity.User;
+import com.bmilab.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.ManyToOne;
@@ -20,7 +20,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "project_participants")
@@ -28,8 +27,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-public class ProjectParticipant {
+public class ProjectParticipant extends BaseTimeEntity {
     @EmbeddedId
     private ProjectParticipantId id;
 

--- a/src/main/java/com/bmilab/backend/domain/project/entity/Timeline.java
+++ b/src/main/java/com/bmilab/backend/domain/project/entity/Timeline.java
@@ -2,9 +2,9 @@ package com.bmilab.backend.domain.project.entity;
 
 import com.bmilab.backend.domain.project.enums.TimelineType;
 import com.bmilab.backend.domain.user.entity.User;
+import com.bmilab.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -24,7 +24,6 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "timelines")
@@ -32,8 +31,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-public class Timeline {
+public class Timeline extends BaseTimeEntity {
     @Id
     @GeneratedValue
     private Long id;

--- a/src/main/java/com/bmilab/backend/domain/report/entity/Report.java
+++ b/src/main/java/com/bmilab/backend/domain/report/entity/Report.java
@@ -2,9 +2,9 @@ package com.bmilab.backend.domain.report.entity;
 
 import com.bmilab.backend.domain.project.entity.Project;
 import com.bmilab.backend.domain.user.entity.User;
+import com.bmilab.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,7 +12,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,9 +19,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "reports")
@@ -30,8 +26,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
-public class Report {
+public class Report extends BaseTimeEntity {
     @Id
     @Column(name = "report_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -52,14 +47,6 @@ public class Report {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
-
-    @CreatedDate
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     public boolean isAuthor(User user) {
         return user.getId().equals(this.user.getId());

--- a/src/main/java/com/bmilab/backend/domain/user/entity/User.java
+++ b/src/main/java/com/bmilab/backend/domain/user/entity/User.java
@@ -1,23 +1,20 @@
 package com.bmilab.backend.domain.user.entity;
 
+import com.bmilab.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import com.bmilab.backend.domain.user.enums.Role;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "users")
@@ -25,8 +22,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
-public class User {
+public class User extends BaseTimeEntity {
     @Id
     @Column(name = "user_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,10 +50,6 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     private Role role;
-
-    @CreatedDate
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
 
     public void updatePassword(String newPassword) {
         this.password = newPassword;

--- a/src/main/java/com/bmilab/backend/domain/user/entity/UserEducation.java
+++ b/src/main/java/com/bmilab/backend/domain/user/entity/UserEducation.java
@@ -1,6 +1,7 @@
 package com.bmilab.backend.domain.user.entity;
 
 import com.bmilab.backend.domain.user.enums.EnrollmentStatus;
+import com.bmilab.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -25,7 +26,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserEducation {
+public class UserEducation extends BaseTimeEntity {
     @Id
     @Column(name = "user_education_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/bmilab/backend/domain/user/entity/UserInfo.java
+++ b/src/main/java/com/bmilab/backend/domain/user/entity/UserInfo.java
@@ -1,9 +1,9 @@
 package com.bmilab.backend.domain.user.entity;
 
 import com.bmilab.backend.domain.project.enums.ProjectCategory;
+import com.bmilab.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserInfo {
+public class UserInfo extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/bmilab/backend/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/bmilab/backend/global/entity/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.bmilab.backend.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- #15 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- BaseTimeEntity 클래스를 작성하여 created_at과 updated_at 필드를 자동으로 처리하도록 구현
- 기존 엔티티들이 BaseTimeEntity를 상속받도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
