### PR TITLE
refactor: 외부 교수를 DB 테이블로 관리하도록 수정

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/project/dto/ExternalProfessorSummary.java
+++ b/src/main/java/com/bmilab/backend/domain/project/dto/ExternalProfessorSummary.java
@@ -1,0 +1,23 @@
+package com.bmilab.backend.domain.project.dto;
+
+public record ExternalProfessorSummary(
+        String name,
+        String organization,
+        String department,
+        String affiliation
+) {
+    public static ExternalProfessorSummary from(String exProfessorString) {
+        String[] split = exProfessorString.split("/");
+
+        if (split.length != 4) {
+            throw new IllegalArgumentException("Invalid ex-professor string: " + exProfessorString);
+        }
+
+        return new ExternalProfessorSummary(
+                split[0],
+                split[1],
+                split[2],
+                split[3]
+        );
+    }
+}

--- a/src/main/java/com/bmilab/backend/domain/project/dto/request/ProjectRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/project/dto/request/ProjectRequest.java
@@ -1,5 +1,6 @@
 package com.bmilab.backend.domain.project.dto.request;
 
+import com.bmilab.backend.domain.project.dto.ExternalProfessorSummary;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
@@ -24,11 +25,11 @@ public record ProjectRequest(
         @Schema(description = "연구 종료일 (있으면)", example = "2025-06-30")
         LocalDate endDate,
 
-        @Schema(description = "PI", example = "김광수")
-        String pi,
+        @Schema(description = "PI")
+        List<ExternalProfessorSummary> piList,
 
-        @Schema(description = "실무 교수", example = "김광수")
-        String practicalProfessor,
+        @Schema(description = "실무 교수")
+        List<ExternalProfessorSummary> practicalProfessors,
 
         @Schema(description = "IRB 번호 (있으면)", example = "IRB-DSEB-...")
         String irbId,

--- a/src/main/java/com/bmilab/backend/domain/project/dto/response/ProjectDetail.java
+++ b/src/main/java/com/bmilab/backend/domain/project/dto/response/ProjectDetail.java
@@ -1,5 +1,6 @@
 package com.bmilab.backend.domain.project.dto.response;
 
+import com.bmilab.backend.domain.project.dto.ExternalProfessorSummary;
 import com.bmilab.backend.domain.project.entity.Project;
 import com.bmilab.backend.domain.project.entity.ProjectFile;
 import com.bmilab.backend.domain.project.entity.ProjectParticipant;
@@ -59,11 +60,11 @@ public record ProjectDetail(
         @Schema(description = "연구 DRB 번호", example = "DRB-DFEF-...")
         String drbId,
 
-        @Schema(description = "PI", example = "김광수")
-        String pi,
+        @Schema(description = "PI 목록")
+        List<ExternalProfessorSummary> piList,
 
-        @Schema(description = "실무 교수", example = "김광수")
-        String practicalProfessor,
+        @Schema(description = "실무 교수 목록")
+        List<ExternalProfessorSummary> practicalProfessors,
 
         @Schema(description = "첨부된 파일 정보 목록")
         List<ProjectFileSummary> files,
@@ -77,7 +78,8 @@ public record ProjectDetail(
         @Schema(description = "연구 생성 시각", example = "2025-04-22T10:15:00")
         LocalDateTime createdAt
 ) {
-    public static ProjectDetail from(Project project, List<ProjectParticipant> participants, List<ProjectFile> projectFiles, boolean isAccessible) {
+    public static ProjectDetail from(Project project, List<ProjectParticipant> participants,
+                                     List<ProjectFile> projectFiles, boolean isAccessible) {
         Map<Boolean, List<ProjectParticipant>> leaderPartitioned = participants.stream()
                 .collect(Collectors.partitioningBy(ProjectParticipant::isLeader));
 
@@ -107,8 +109,16 @@ public record ProjectDetail(
                 .status(project.getStatus())
                 .irbId(project.getIrbId())
                 .drbId(project.getDrbId())
-                .pi(project.getPi())
-                .practicalProfessor(project.getPracticalProfessor())
+                .piList(
+                        project.getPIList().stream()
+                                .map(ExternalProfessorSummary::from)
+                                .toList()
+                )
+                .practicalProfessors(
+                        project.getPracticalProfessorList().stream()
+                                .map(ExternalProfessorSummary::from)
+                                .toList()
+                )
                 .files(projectFiles.stream()
                         .filter(file -> file.getType() == ProjectFileType.GENERAL)
                         .map(ProjectFileSummary::from)

--- a/src/main/java/com/bmilab/backend/domain/project/dto/response/ProjectFindAllResponse.java
+++ b/src/main/java/com/bmilab/backend/domain/project/dto/response/ProjectFindAllResponse.java
@@ -1,11 +1,13 @@
 package com.bmilab.backend.domain.project.dto.response;
 
+import com.bmilab.backend.domain.project.dto.ExternalProfessorSummary;
 import com.bmilab.backend.domain.project.dto.query.GetAllProjectsQueryResult;
 import com.bmilab.backend.domain.project.enums.ProjectStatus;
 import com.bmilab.backend.domain.projectcategory.dto.response.ProjectCategorySummary;
 import com.bmilab.backend.domain.user.dto.response.UserSummary;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 import lombok.Builder;
 
@@ -32,11 +34,11 @@ public record ProjectFindAllResponse(
             @Schema(description = "연구 종료일", example = "2025-06-30")
             LocalDate endDate,
 
-            @Schema(description = "PI", example = "김광수")
-            String pi,
+            @Schema(description = "PI 목록")
+            List<ExternalProfessorSummary> piList,
 
-            @Schema(description = "실무 교수", example = "김광수")
-            String practicalProfessor,
+            @Schema(description = "실무 교수 목록")
+            List<ExternalProfessorSummary> practicalProfessors,
 
             @Schema(description = "연구 책임자 목록")
             List<UserSummary> leaders,
@@ -60,8 +62,14 @@ public record ProjectFindAllResponse(
                     .category(ProjectCategorySummary.from(queryResult.getCategory()))
                     .startDate(queryResult.getStartDate())
                     .endDate(queryResult.getEndDate())
-                    .pi(queryResult.getPi())
-                    .practicalProfessor(queryResult.getPracticalProfessor())
+                    .piList(
+                            Arrays.stream(queryResult.getPi().split(","))
+                                    .map(ExternalProfessorSummary::from).toList()
+                    )
+                    .practicalProfessors(
+                            Arrays.stream(queryResult.getPracticalProfessor().split(","))
+                                    .map(ExternalProfessorSummary::from).toList()
+                    )
                     .leaders(queryResult.getLeaders()
                             .stream()
                             .map(UserSummary::from)

--- a/src/main/java/com/bmilab/backend/domain/project/entity/ExternalProfessor.java
+++ b/src/main/java/com/bmilab/backend/domain/project/entity/ExternalProfessor.java
@@ -1,0 +1,39 @@
+package com.bmilab.backend.domain.project.entity;
+
+import com.bmilab.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ex_professors")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ExternalProfessor extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ex_professor_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String organization;
+
+    @Column(nullable = false)
+    private String department;
+
+    @Column(nullable = false)
+    private String affiliation;
+}

--- a/src/main/java/com/bmilab/backend/domain/project/entity/Project.java
+++ b/src/main/java/com/bmilab/backend/domain/project/entity/Project.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -85,6 +86,8 @@ public class Project extends BaseTimeEntity {
             String content,
             LocalDate startDate,
             LocalDate endDate,
+            List<String> piList,
+            List<String> practicalProfessorList,
             ProjectCategory category,
             ProjectStatus status,
             boolean isPrivate
@@ -93,6 +96,8 @@ public class Project extends BaseTimeEntity {
         this.content = content;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.pi = String.join(",", piList);
+        this.practicalProfessor = String.join(",", practicalProfessorList);
         this.category = category;
         this.status = status;
         this.isPrivate = isPrivate;
@@ -101,5 +106,13 @@ public class Project extends BaseTimeEntity {
     public void complete(LocalDate endDate) {
         this.endDate = endDate;
         this.status = ProjectStatus.COMPLETED;
+    }
+
+    public List<String> getPIList() {
+        return List.of(pi.split(","));
+    }
+
+    public List<String> getPracticalProfessorList() {
+        return List.of(practicalProfessor.split(","));
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/project/event/ProjectUpdateEvent.java
+++ b/src/main/java/com/bmilab/backend/domain/project/event/ProjectUpdateEvent.java
@@ -1,0 +1,8 @@
+package com.bmilab.backend.domain.project.event;
+
+import com.bmilab.backend.domain.project.entity.Project;
+
+public record ProjectUpdateEvent(
+        Project project
+) {
+}

--- a/src/main/java/com/bmilab/backend/domain/project/event/listener/ProjectUpdateEventListener.java
+++ b/src/main/java/com/bmilab/backend/domain/project/event/listener/ProjectUpdateEventListener.java
@@ -1,0 +1,51 @@
+package com.bmilab.backend.domain.project.event.listener;
+
+import com.bmilab.backend.domain.project.dto.ExternalProfessorSummary;
+import com.bmilab.backend.domain.project.entity.ExternalProfessor;
+import com.bmilab.backend.domain.project.entity.Project;
+import com.bmilab.backend.domain.project.event.ProjectUpdateEvent;
+import com.bmilab.backend.domain.project.repository.ExternalProfessorRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectUpdateEventListener {
+    private final ExternalProfessorRepository externalProfessorRepository;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onProjectUpdate(ProjectUpdateEvent event) {
+        Project project = event.project();
+        List<String> exProfessorStrings = new ArrayList<>();
+
+        exProfessorStrings.addAll(project.getPIList());
+        exProfessorStrings.addAll(project.getPracticalProfessorList());
+
+        Set<ExternalProfessorSummary> externalProfessors = exProfessorStrings.stream()
+                .map(ExternalProfessorSummary::from)
+                .collect(Collectors.toSet());
+
+        List<ExternalProfessorSummary> exists = externalProfessorRepository.findExists(externalProfessors);
+
+        externalProfessors.removeAll(exists);
+
+        externalProfessors.stream()
+                .map(dto ->
+                        ExternalProfessor.builder()
+                                .name(dto.name())
+                                .organization(dto.organization())
+                                .department(dto.department())
+                                .affiliation(dto.affiliation())
+                                .build()
+                )
+                .forEach(externalProfessorRepository::save);
+    }
+}

--- a/src/main/java/com/bmilab/backend/domain/project/repository/ExternalProfessorRepository.java
+++ b/src/main/java/com/bmilab/backend/domain/project/repository/ExternalProfessorRepository.java
@@ -1,0 +1,7 @@
+package com.bmilab.backend.domain.project.repository;
+
+import com.bmilab.backend.domain.project.entity.ExternalProfessor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExternalProfessorRepository extends JpaRepository<ExternalProfessor, Long>, ExternalProfessorRepositoryCustom {
+}

--- a/src/main/java/com/bmilab/backend/domain/project/repository/ExternalProfessorRepositoryCustom.java
+++ b/src/main/java/com/bmilab/backend/domain/project/repository/ExternalProfessorRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.bmilab.backend.domain.project.repository;
+
+import com.bmilab.backend.domain.project.dto.ExternalProfessorSummary;
+import java.util.List;
+
+public interface ExternalProfessorRepositoryCustom {
+    List<ExternalProfessorSummary> findExists(Iterable<ExternalProfessorSummary> keys);
+}

--- a/src/main/java/com/bmilab/backend/domain/project/repository/ExternalProfessorRepositoryCustomImpl.java
+++ b/src/main/java/com/bmilab/backend/domain/project/repository/ExternalProfessorRepositoryCustomImpl.java
@@ -1,0 +1,43 @@
+package com.bmilab.backend.domain.project.repository;
+
+import com.bmilab.backend.domain.project.dto.ExternalProfessorSummary;
+import com.bmilab.backend.domain.project.entity.QExternalProfessor;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ExternalProfessorRepositoryCustomImpl implements ExternalProfessorRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ExternalProfessorSummary> findExists(Iterable<ExternalProfessorSummary> keys) {
+        QExternalProfessor ep = QExternalProfessor.externalProfessor;
+
+        BooleanBuilder conditionBuilder = new BooleanBuilder();
+
+        keys.forEach((key) ->
+                conditionBuilder.or(
+                        ep.name.eq(key.name())
+                                .and(ep.organization.eq(key.organization()))
+                                .and(ep.department.eq(key.department()))
+                                .and(ep.affiliation.eq(key.affiliation()))
+                )
+        );
+
+        return queryFactory
+                .select(Projections.constructor(
+                        ExternalProfessorSummary.class,
+                        ep.name,
+                        ep.organization,
+                        ep.department,
+                        ep.affiliation
+                ))
+                .from(ep)
+                .where(conditionBuilder)
+                .fetch();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#21 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

PI, 실무교수 같은 외부 교수 정보를 DB 테이블로 관리하도록 수정했습니다.
Spring Event를 사용하여 연구가 업데이트될 때마다 외부 교수 목록을 확인하여 데이터가 존재하지 않을 경우 데이터를 추가합니다.
 
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
