### PR TITLE
refactor: 사용자 검색 조건을 부분 일치로 개선

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/bmilab/backend/domain/user/repository/UserRepositoryCustomImpl.java
@@ -132,16 +132,17 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
         String filterBy = condition.filterBy();
         String filterValue = condition.filterValue();
 
+
         if (filterBy != null && filterValue != null) {
             switch (filterBy) {
-                case "name" -> conditionBuilder.and(user.name.eq(filterValue));
-                case "email" -> conditionBuilder.and(user.email.eq(filterValue));
-                case "department" -> conditionBuilder.and(user.department.eq(filterValue));
-                case "organization" -> conditionBuilder.and(user.organization.eq(filterValue));
+                case "name" -> conditionBuilder.and(user.name.containsIgnoreCase(filterValue));
+                case "email" -> conditionBuilder.and(user.email.containsIgnoreCase(filterValue));
+                case "department" -> conditionBuilder.and(user.department.containsIgnoreCase(filterValue));
+                case "organization" -> conditionBuilder.and(user.organization.containsIgnoreCase(filterValue));
                 case "affiliation" -> conditionBuilder.and(user.affiliation.eq(UserAffiliation.valueOf(filterValue.toUpperCase())));
-                case "projectName" -> conditionBuilder.and(category.name.eq(filterValue));
-                case "seatNumber" -> conditionBuilder.and(userInfo.seatNumber.eq(filterValue));
-                case "phoneNumber" -> conditionBuilder.and(userInfo.phoneNumber.eq(filterValue));
+                case "projectName" -> conditionBuilder.and(category.name.containsIgnoreCase(filterValue));
+                case "seatNumber" -> conditionBuilder.and(userInfo.seatNumber.containsIgnoreCase(filterValue));
+                case "phoneNumber" -> conditionBuilder.and(userInfo.phoneNumber.containsIgnoreCase(filterValue));
             }
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#23 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 기존 사용자 검색 조건이 `eq()` 기반으로 동작하여, 필드 값과 정확히 일치하는 경우에만 검색이 가능했지만, 이를 `containsIgnoreCase()`로 변경하여, 부분 일치(대소문자 무시) 검색이 가능하도록 개선했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
