### PR TITLE
refactor: 관리자 전용 일일 업무 보고 검색/필터 기능 분리 및 사용자 API 정리

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/project/controller/ProjectApi.java
+++ b/src/main/java/com/bmilab/backend/domain/project/controller/ProjectApi.java
@@ -155,7 +155,8 @@ public interface ProjectApi {
             @PathVariable Long projectId,
             @RequestParam(required = false) Long userId,
             @RequestParam(required = false) LocalDate startDate,
-            @RequestParam(required = false) LocalDate endDate
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(required = false) String keyword
     );
 
     @Operation(summary = "모든 연구 조회", description = "모든 연구를 조회하는 GET API")

--- a/src/main/java/com/bmilab/backend/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/bmilab/backend/domain/project/controller/ProjectController.java
@@ -98,7 +98,8 @@ public class ProjectController implements ProjectApi {
             @PathVariable Long projectId,
             @RequestParam(required = false) Long userId,
             @RequestParam(required = false) LocalDate startDate,
-            @RequestParam(required = false) LocalDate endDate
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(required = false) String keyword
     ) {
 
         return ResponseEntity.ok(projectService.getReportsByProject(
@@ -106,7 +107,8 @@ public class ProjectController implements ProjectApi {
                 projectId,
                 userId,
                 startDate,
-                endDate
+                endDate,
+                null
         ));
     }
 

--- a/src/main/java/com/bmilab/backend/domain/project/service/ProjectService.java
+++ b/src/main/java/com/bmilab/backend/domain/project/service/ProjectService.java
@@ -397,8 +397,8 @@ public class ProjectService {
 
         validateProjectAccessPermission(project, user, ProjectAccessPermission.EDIT, true);
 
-        List<GetAllReportsQueryResult> results = reportRepository.findAllWithFiles(filterUserId, projectId,
-                startDate, endDate, keyword);
+        List<GetAllReportsQueryResult> results = reportRepository.findReportsByUser(filterUserId, projectId,
+                startDate, endDate);
 
         return ReportFindAllResponse.of(results);
     }

--- a/src/main/java/com/bmilab/backend/domain/report/controller/AdminReportApi.java
+++ b/src/main/java/com/bmilab/backend/domain/report/controller/AdminReportApi.java
@@ -1,0 +1,31 @@
+package com.bmilab.backend.domain.report.controller;
+
+import com.bmilab.backend.domain.report.dto.response.ReportFindAllResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+
+@Tag(name = "(Admin)Report", description = "(관리자용) 일일 업무 보고 API")
+public interface AdminReportApi {
+    @Operation(summary = "일일 업무 보고 조회", description = "일일 업무 보고를 조회하는 API")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "업무 보고 조회 성공"
+                    ),
+            }
+    )
+    ResponseEntity<ReportFindAllResponse> getReportsByAllUser(
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) Long projectId,
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(required = false) String keyword
+    );
+}

--- a/src/main/java/com/bmilab/backend/domain/report/controller/AdminReportController.java
+++ b/src/main/java/com/bmilab/backend/domain/report/controller/AdminReportController.java
@@ -1,0 +1,38 @@
+package com.bmilab.backend.domain.report.controller;
+
+import com.bmilab.backend.domain.report.dto.response.ReportFindAllResponse;
+import com.bmilab.backend.domain.report.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/admin/reports")
+@RequiredArgsConstructor
+public class AdminReportController implements AdminReportApi{
+
+    private final ReportService reportService;
+
+    @GetMapping
+    public ResponseEntity<ReportFindAllResponse> getReportsByAllUser(
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) Long projectId,
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(required = false) String keyword
+    ) {
+
+        return ResponseEntity.ok(reportService.getReportsByAllUser(
+                userId,
+                projectId,
+                startDate,
+                endDate,
+                keyword
+        ));
+    }
+}

--- a/src/main/java/com/bmilab/backend/domain/report/controller/ReportApi.java
+++ b/src/main/java/com/bmilab/backend/domain/report/controller/ReportApi.java
@@ -73,7 +73,6 @@ public interface ReportApi {
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @RequestParam(required = false) Long projectId,
             @RequestParam(required = false) LocalDate startDate,
-            @RequestParam(required = false) LocalDate endDate,
-            @RequestParam(required = false) String keyword
+            @RequestParam(required = false) LocalDate endDate
     );
 }

--- a/src/main/java/com/bmilab/backend/domain/report/controller/ReportApi.java
+++ b/src/main/java/com/bmilab/backend/domain/report/controller/ReportApi.java
@@ -7,12 +7,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.time.LocalDate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
 
 @Tag(name = "Report", description = "일일 업무 보고 API")
 public interface ReportApi {
@@ -72,6 +73,7 @@ public interface ReportApi {
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @RequestParam(required = false) Long projectId,
             @RequestParam(required = false) LocalDate startDate,
-            @RequestParam(required = false) LocalDate endDate
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(required = false) String keyword
     );
 }

--- a/src/main/java/com/bmilab/backend/domain/report/controller/ReportController.java
+++ b/src/main/java/com/bmilab/backend/domain/report/controller/ReportController.java
@@ -62,16 +62,14 @@ public class ReportController implements ReportApi {
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @RequestParam(required = false) Long projectId,
             @RequestParam(required = false) LocalDate startDate,
-            @RequestParam(required = false) LocalDate endDate,
-            @RequestParam(required = false) String keyword
+            @RequestParam(required = false) LocalDate endDate
     ) {
 
         return ResponseEntity.ok(reportService.getReportsByCurrentUser(
                 userAuthInfo.getUserId(),
                 projectId,
                 startDate,
-                endDate,
-                keyword
+                endDate
         ));
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/report/controller/ReportController.java
+++ b/src/main/java/com/bmilab/backend/domain/report/controller/ReportController.java
@@ -4,7 +4,6 @@ import com.bmilab.backend.domain.report.dto.request.ReportRequest;
 import com.bmilab.backend.domain.report.dto.response.ReportFindAllResponse;
 import com.bmilab.backend.domain.report.service.ReportService;
 import com.bmilab.backend.global.security.UserAuthInfo;
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,10 +17,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
+
 @RestController
 @RequestMapping("/reports")
 @RequiredArgsConstructor
 public class ReportController implements ReportApi {
+
     private final ReportService reportService;
 
     @PostMapping
@@ -29,6 +31,7 @@ public class ReportController implements ReportApi {
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @RequestBody ReportRequest request
     ) {
+
         reportService.createReport(userAuthInfo.getUserId(), request);
         return ResponseEntity.ok().build();
     }
@@ -39,6 +42,7 @@ public class ReportController implements ReportApi {
             @PathVariable Long reportId,
             @RequestBody ReportRequest request
     ) {
+
         reportService.updateReport(userAuthInfo.getUserId(), reportId, request);
         return ResponseEntity.ok().build();
     }
@@ -48,6 +52,7 @@ public class ReportController implements ReportApi {
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @PathVariable Long reportId
     ) {
+
         reportService.deleteReport(userAuthInfo.getUserId(), reportId);
         return ResponseEntity.ok().build();
     }
@@ -57,8 +62,16 @@ public class ReportController implements ReportApi {
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @RequestParam(required = false) Long projectId,
             @RequestParam(required = false) LocalDate startDate,
-            @RequestParam(required = false) LocalDate endDate
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(required = false) String keyword
     ) {
-        return ResponseEntity.ok(reportService.getReportsByCurrentUser(userAuthInfo.getUserId(), projectId, startDate, endDate));
+
+        return ResponseEntity.ok(reportService.getReportsByCurrentUser(
+                userAuthInfo.getUserId(),
+                projectId,
+                startDate,
+                endDate,
+                keyword
+        ));
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/report/repository/ReportRepositoryCustom.java
+++ b/src/main/java/com/bmilab/backend/domain/report/repository/ReportRepositoryCustom.java
@@ -7,7 +7,14 @@ import java.util.List;
 
 public interface ReportRepositoryCustom {
 
-    List<GetAllReportsQueryResult> findAllWithFiles(
+    List<GetAllReportsQueryResult> findReportsByUser(
+            Long userId,
+            Long projectId,
+            LocalDate startDate,
+            LocalDate endDate
+    );
+
+    List<GetAllReportsQueryResult> findReportsByCondition(
             Long userId,
             Long projectId,
             LocalDate startDate,

--- a/src/main/java/com/bmilab/backend/domain/report/repository/ReportRepositoryCustom.java
+++ b/src/main/java/com/bmilab/backend/domain/report/repository/ReportRepositoryCustom.java
@@ -1,9 +1,17 @@
 package com.bmilab.backend.domain.report.repository;
 
 import com.bmilab.backend.domain.report.dto.query.GetAllReportsQueryResult;
+
 import java.time.LocalDate;
 import java.util.List;
 
 public interface ReportRepositoryCustom {
-    List<GetAllReportsQueryResult> findAllWithFiles(Long userId, Long projectId, LocalDate startDate, LocalDate endDate);
+
+    List<GetAllReportsQueryResult> findAllWithFiles(
+            Long userId,
+            Long projectId,
+            LocalDate startDate,
+            LocalDate endDate,
+            String keyword
+    );
 }

--- a/src/main/java/com/bmilab/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/bmilab/backend/domain/report/service/ReportService.java
@@ -87,11 +87,28 @@ public class ReportService {
             Long userId,
             Long projectId,
             LocalDate startDate,
+            LocalDate endDate
+    ) {
+
+        List<GetAllReportsQueryResult> results = reportRepository.findReportsByUser(
+                userId,
+                projectId,
+                startDate,
+                endDate
+        );
+
+        return ReportFindAllResponse.of(results);
+    }
+
+    public ReportFindAllResponse getReportsByAllUser(
+            Long userId,
+            Long projectId,
+            LocalDate startDate,
             LocalDate endDate,
             String keyword
     ) {
 
-        List<GetAllReportsQueryResult> results = reportRepository.findAllWithFiles(
+        List<GetAllReportsQueryResult> results = reportRepository.findReportsByCondition(
                 userId,
                 projectId,
                 startDate,

--- a/src/main/java/com/bmilab/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/bmilab/backend/domain/report/service/ReportService.java
@@ -15,16 +15,18 @@ import com.bmilab.backend.domain.report.repository.ReportRepository;
 import com.bmilab.backend.domain.user.entity.User;
 import com.bmilab.backend.domain.user.service.UserService;
 import com.bmilab.backend.global.exception.ApiException;
-import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReportService {
+
     private final ReportRepository reportRepository;
     private final UserService userService;
     private final FileInformationRepository fileInformationRepository;
@@ -32,12 +34,14 @@ public class ReportService {
     private final ProjectService projectService;
 
     public Report findReportById(Long reportId) {
+
         return reportRepository.findById(reportId)
                 .orElseThrow(() -> new ApiException(ReportErrorCode.REPORT_NOT_FOUND));
     }
 
     @Transactional
     public void createReport(Long userId, ReportRequest request) {
+
         User user = userService.findUserById(userId);
 
         Long projectId = request.projectId();
@@ -61,6 +65,7 @@ public class ReportService {
 
     @Transactional
     public void updateReport(Long userId, Long reportId, ReportRequest request) {
+
         User user = userService.findUserById(userId);
 
         Long projectId = request.projectId();
@@ -78,16 +83,28 @@ public class ReportService {
         files.forEach(file -> file.updateDomain(FileDomainType.REPORT, report.getId()));
     }
 
-    public ReportFindAllResponse getReportsByCurrentUser(Long userId, Long projectId, LocalDate startDate,
-                                                         LocalDate endDate) {
+    public ReportFindAllResponse getReportsByCurrentUser(
+            Long userId,
+            Long projectId,
+            LocalDate startDate,
+            LocalDate endDate,
+            String keyword
+    ) {
+
         List<GetAllReportsQueryResult> results = reportRepository.findAllWithFiles(
-                userId, projectId, startDate, endDate);
+                userId,
+                projectId,
+                startDate,
+                endDate,
+                keyword
+        );
 
         return ReportFindAllResponse.of(results);
     }
 
     @Transactional
     public void deleteReport(Long userId, Long reportId) {
+
         User user = userService.findUserById(userId);
 
         Report report = findReportById(reportId);
@@ -99,6 +116,7 @@ public class ReportService {
     }
 
     private void validateUserIsReportAuthor(User user, Report report) {
+
         if (!report.isAuthor(user)) {
             throw new ApiException(ReportErrorCode.REPORT_ACCESS_DENIED);
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- #27 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 기존에 사용자용 일일 업무 보고 API(`/reports`)에 관리자 기능(userId 필터, keyword 검색)을 잘못 구현했던 부분을 수정
- 관리자 전용 일일 업무 보고 API(`/admin/reports`)를 새로 분리하여 관리자 필터 조건 및 검색 기능 구현
- 사용자 API는 로그인한 본인의 보고서만 조회하도록 원래 목적에 맞게 정리
- 서비스 및 레포지토리 레벨에서 메서드 역할 분리:
  - `findReportsByUser` → 사용자용 (본인 조회)
  - `findReportsByCondition` → 관리자용 (조건 검색)
- 잘못된 위치에 구현됐던 필터/검색 로직 제거 및 구조 정리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
