### PR TITLE
HOTFIX: /user/search 기능 /user로 이동 및 기존 기능 복원

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/user/controller/UserApi.java
+++ b/src/main/java/com/bmilab/backend/domain/user/controller/UserApi.java
@@ -1,10 +1,10 @@
 package com.bmilab.backend.domain.user.controller;
 
+import com.bmilab.backend.domain.user.dto.query.UserCondition;
 import com.bmilab.backend.domain.user.dto.request.FindPasswordEmailRequest;
 import com.bmilab.backend.domain.user.dto.request.UpdateUserPasswordRequest;
 import com.bmilab.backend.domain.user.dto.request.UpdateUserRequest;
 import com.bmilab.backend.domain.user.dto.request.UserEducationRequest;
-import com.bmilab.backend.domain.user.dto.query.UserSearchCondition;
 import com.bmilab.backend.domain.user.dto.response.SearchUserResponse;
 import com.bmilab.backend.domain.user.dto.response.UserDetail;
 import com.bmilab.backend.domain.user.dto.response.UserFindAllResponse;
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -56,9 +57,8 @@ public interface UserApi {
             }
     )
     ResponseEntity<UserFindAllResponse> getAllUsers(
-            @RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
-            @RequestParam(required = false, defaultValue = "10") int size,
-            @RequestParam(required = false, defaultValue = "createdAt", value = "criteria") String criteria);
+            @ParameterObject @ModelAttribute UserCondition condition
+    );
 
     @Operation(summary = "현재 사용자 정보 상세 조회", description = "현재 로그인한 사용자 정보를 상세 조회하는 GET API")
     @ApiResponses(
@@ -126,7 +126,7 @@ public interface UserApi {
             }
     )
     ResponseEntity<SearchUserResponse> searchUsers(
-            @ModelAttribute UserSearchCondition request
+            @RequestParam(required = false) String keyword
     );
 
     @Operation(summary = "사용자 학력 추가", description = "사용자의 학력을 추가하기 위한 PATCH API")

--- a/src/main/java/com/bmilab/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/bmilab/backend/domain/user/controller/UserController.java
@@ -1,10 +1,10 @@
 package com.bmilab.backend.domain.user.controller;
 
+import com.bmilab.backend.domain.user.dto.query.UserCondition;
 import com.bmilab.backend.domain.user.dto.request.FindPasswordEmailRequest;
-import com.bmilab.backend.domain.user.dto.request.UserEducationRequest;
 import com.bmilab.backend.domain.user.dto.request.UpdateUserPasswordRequest;
 import com.bmilab.backend.domain.user.dto.request.UpdateUserRequest;
-import com.bmilab.backend.domain.user.dto.query.UserSearchCondition;
+import com.bmilab.backend.domain.user.dto.request.UserEducationRequest;
 import com.bmilab.backend.domain.user.dto.response.SearchUserResponse;
 import com.bmilab.backend.domain.user.dto.response.UserDetail;
 import com.bmilab.backend.domain.user.dto.response.UserFindAllResponse;
@@ -46,19 +46,16 @@ public class UserController implements UserApi {
 
     @GetMapping
     public ResponseEntity<UserFindAllResponse> getAllUsers(
-            @RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
-            @RequestParam(required = false, defaultValue = "10") int size,
-            @RequestParam(required = false, defaultValue = "createdAt", value = "criteria") String criteria
+            @ParameterObject @ModelAttribute UserCondition condition
     ) {
-
-        return ResponseEntity.ok(userService.getAllUsers(pageNo, size, criteria));
+        return ResponseEntity.ok(userService.getAllUsers(condition));
     }
 
     @GetMapping("/search")
     public ResponseEntity<SearchUserResponse> searchUsers(
-            @ParameterObject @ModelAttribute UserSearchCondition request
+            @RequestParam(required = false) String keyword
     ) {
-        return ResponseEntity.ok(userService.searchUsers(request));
+        return ResponseEntity.ok(userService.searchUsers(keyword));
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/bmilab/backend/domain/user/dto/query/UserCondition.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/query/UserCondition.java
@@ -1,0 +1,17 @@
+package com.bmilab.backend.domain.user.dto.query;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserCondition {
+    private String filterBy;
+    private String filterValue;
+    private String direction;
+    private Integer pageNo = 0;
+    private Integer size = 10;
+    private String criteria = "createdAt";
+}

--- a/src/main/java/com/bmilab/backend/domain/user/dto/query/UserSearchCondition.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/query/UserSearchCondition.java
@@ -1,8 +1,0 @@
-package com.bmilab.backend.domain.user.dto.query;
-
-public record UserSearchCondition(
-        String filterBy,
-        String filterValue,
-        String sort
-) {
-}

--- a/src/main/java/com/bmilab/backend/domain/user/dto/response/SearchUserResponse.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/response/SearchUserResponse.java
@@ -1,6 +1,5 @@
 package com.bmilab.backend.domain.user.dto.response;
 
-import com.bmilab.backend.domain.user.dto.query.UserSearchCondition;
 import com.bmilab.backend.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -8,26 +7,13 @@ import java.util.List;
 
 public record SearchUserResponse(
         @Schema(description = "검색된 사용자 정보")
-        List<UserSummary> users,
-
-        @Schema(description = "검색 필터 필드", example = "name")
-        String filterBy,
-
-        @Schema(description = "검색 필터 값", example = "홍길동")
-        String filterValue,
-
-        @Schema(description = "정렬 조건", example = "이름 오름차순")
-        String sort
-
+        List<UserSummary> users
 ) {
-    public static SearchUserResponse of(List<User> users, UserSearchCondition condition) {
+    public static SearchUserResponse of(List<User> results) {
         return new SearchUserResponse(
-            users.stream()
+                results.stream()
                     .map(UserSummary::from)
-                    .toList(),
-                condition.filterBy(),
-                condition.filterValue(),
-                condition.sort()
+                    .toList()
         );
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/user/dto/response/UserFindAllResponse.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/response/UserFindAllResponse.java
@@ -1,25 +1,41 @@
 package com.bmilab.backend.domain.user.dto.response;
 
 import com.bmilab.backend.domain.projectcategory.dto.response.ProjectCategorySummary;
+import com.bmilab.backend.domain.user.dto.query.UserCondition;
 import com.bmilab.backend.domain.user.dto.query.UserInfoQueryResult;
 import com.bmilab.backend.domain.user.entity.User;
 import com.bmilab.backend.domain.user.entity.UserInfo;
 import com.bmilab.backend.domain.user.enums.UserAffiliation;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
 import lombok.Builder;
 import org.springframework.data.domain.Page;
 
+import java.util.List;
+
 public record UserFindAllResponse(
         List<UserItem> users,
+
+        @Schema(description = "검색 필터 필드", example = "name")
+        String filterBy,
+
+        @Schema(description = "검색 필터 값", example = "홍길동")
+        String filterValue,
+
+        @Schema(description = "필터 내 정렬 기준", example = "이름 오름차순")
+        String sort,
+
+        @Schema(description = "전체 페이지 수", example = "5")
         int totalPage
 ) {
-    public static UserFindAllResponse of(Page<UserInfoQueryResult> queryResults) {
+    public static UserFindAllResponse of(UserCondition condition, Page<UserInfoQueryResult> queryResults) {
         return new UserFindAllResponse(
                 queryResults.getContent()
                         .stream()
                         .map(UserItem::from)
                         .toList(),
+                condition.getFilterBy(),
+                condition.getFilterValue(),
+                condition.getDirection(),
                 queryResults.getTotalPages()
         );
     }
@@ -77,9 +93,9 @@ public record UserFindAllResponse(
                                     .map(ProjectCategorySummary::from)
                                     .toList()
                     )
-                    .seatNumber(userInfo.getSeatNumber())
-                    .phoneNumber(userInfo.getPhoneNumber())
-                    .education(userInfo.getEducation())
+                    .seatNumber(userInfo != null ? userInfo.getSeatNumber() : null)
+                    .phoneNumber(userInfo != null ? userInfo.getPhoneNumber() : null)
+                    .education(userInfo != null ? userInfo.getEducation() : null)
                     .build();
         }
     }

--- a/src/main/java/com/bmilab/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/bmilab/backend/domain/user/repository/UserRepository.java
@@ -16,5 +16,12 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     @Query("select u from User u where u.id in :ids")
     List<User> findAllByIds(Set<Long> ids);
 
+    @Query("SELECT u FROM User u WHERE :name IS NULL "
+            + "OR :name = '' "
+            + "OR u.name LIKE CONCAT('%', :name, '%') "
+            + "OR u.email LIKE CONCAT('%', :name, '%') "
+            + "OR u.department LIKE CONCAT('%', :name, '%')")
+    List<User> searchUsersByKeyword(String name);
+
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/bmilab/backend/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/bmilab/backend/domain/user/repository/UserRepositoryCustom.java
@@ -1,19 +1,15 @@
 package com.bmilab.backend.domain.user.repository;
 
+import com.bmilab.backend.domain.user.dto.query.UserCondition;
 import com.bmilab.backend.domain.user.dto.query.UserDetailQueryResult;
 import com.bmilab.backend.domain.user.dto.query.UserInfoQueryResult;
-import com.bmilab.backend.domain.user.dto.query.UserSearchCondition;
-import com.bmilab.backend.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface UserRepositoryCustom {
     Optional<UserDetailQueryResult> findUserDetailsById(Long userId);
 
-    Page<UserInfoQueryResult> findAllUserInfosPagination(Pageable pageable);
-
-    List<User> searchUsersByCondition(UserSearchCondition condition);
+    Page<UserInfoQueryResult> searchUserInfos(UserCondition condition, Pageable pageable);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- #36 

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- /users/search에 구현된 연명부 조회 기능을 /users로 이전
- /users의 기존 페이지네이션 로직에 필터 및 정렬 기능 통합
- /users/search는 원래 상태로 롤백

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
