### PR TITLE
feat: DTO 유효성 검사(validation) 추가

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/file/controller/FileController.java
+++ b/src/main/java/com/bmilab/backend/domain/file/controller/FileController.java
@@ -5,12 +5,7 @@ import com.bmilab.backend.domain.file.dto.response.FilePresignedUrlResponse;
 import com.bmilab.backend.domain.file.dto.response.FileSummary;
 import com.bmilab.backend.domain.file.enums.FileDomainType;
 import com.bmilab.backend.domain.file.service.FileService;
-
-import java.net.URLDecoder;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-
-import java.util.UUID;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -21,6 +16,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/files")
@@ -42,7 +41,7 @@ public class FileController implements FileApi {
     }
 
     @PostMapping
-    public ResponseEntity<FileSummary> uploadFile(@RequestBody UploadFileRequest request) {
+    public ResponseEntity<FileSummary> uploadFile(@RequestBody @Valid UploadFileRequest request) {
 
         return ResponseEntity.ok(fileService.uploadFile(request));
     }

--- a/src/main/java/com/bmilab/backend/domain/file/dto/request/UploadFileRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/file/dto/request/UploadFileRequest.java
@@ -1,14 +1,32 @@
 package com.bmilab.backend.domain.file.dto.request;
 
 import com.bmilab.backend.domain.file.enums.FileDomainType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
 public record UploadFileRequest(
+        @Schema(description = "UUID", example = "123e4567-e89b-12d3-a456-426614174000")
+        @NotNull(message = "UUID는 필수입니다.")
         UUID uuid,
+
+        @Schema(description = "파일 이름", example = "글로우업 AI 에디터 개발")
+        @NotBlank(message = "파일 이름은 필수입니다.")
         String fileName,
+
+        @Schema(description = "파일 확장자", example = "pdf")
+        @NotBlank(message = "파일 확장자는 필수입니다.")
         String extension,
+
+        @Schema(description = "파일 크기 (바이트 단위)", example = "1024")
+        @Min(value = 1, message = "파일 크기는 1바이트 이상이어야 합니다.")
         long size,
+
+        @Schema(description = "파일 도메인 타입", example = "PROJECT")
+        @NotNull(message = "파일 도메인 타입은 필수입니다.")
         FileDomainType domainType
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/leave/controller/AdminLeaveController.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/controller/AdminLeaveController.java
@@ -3,6 +3,7 @@ package com.bmilab.backend.domain.leave.controller;
 import com.bmilab.backend.domain.leave.dto.request.RejectLeaveRequest;
 import com.bmilab.backend.domain.leave.service.LeaveService;
 import com.bmilab.backend.global.annotation.OnlyAdmin;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,7 +28,7 @@ public class AdminLeaveController implements AdminLeaveApi {
     @PostMapping("/{leaveId}/reject")
     public ResponseEntity<Void> rejectLeave(
             @PathVariable long leaveId,
-            @RequestBody RejectLeaveRequest request
+            @RequestBody @Valid RejectLeaveRequest request
     ) {
         leaveService.rejectLeave(leaveId, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/bmilab/backend/domain/leave/controller/LeaveController.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/controller/LeaveController.java
@@ -4,7 +4,7 @@ import com.bmilab.backend.domain.leave.dto.request.ApplyLeaveRequest;
 import com.bmilab.backend.domain.leave.dto.response.LeaveFindAllResponse;
 import com.bmilab.backend.domain.leave.service.LeaveService;
 import com.bmilab.backend.global.security.UserAuthInfo;
-import java.time.LocalDateTime;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/leaves")
@@ -39,7 +41,7 @@ public class LeaveController implements LeaveApi {
     @PostMapping
     public ResponseEntity<Void> applyLeave(
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
-            @RequestBody ApplyLeaveRequest request
+            @RequestBody @Valid ApplyLeaveRequest request
     ) {
         leaveService.applyLeave(userAuthInfo.getUserId(), request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/bmilab/backend/domain/leave/dto/request/ApplyLeaveRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/dto/request/ApplyLeaveRequest.java
@@ -2,19 +2,29 @@ package com.bmilab.backend.domain.leave.dto.request;
 
 import com.bmilab.backend.domain.leave.enums.LeaveType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.format.annotation.DateTimeFormat;
+
 import java.time.LocalDateTime;
 
 public record ApplyLeaveRequest(
         @Schema(description = "휴가 시작 일시", example = "2025-05-01T09:00:00")
+        @NotNull(message = "휴가 시작 일시는 필수입니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime startDate,
 
         @Schema(description = "휴가 종료 일시", example = "2025-05-02T18:00:00")
+        @NotNull(message = "휴가 종료 일시는 필수입니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime endDate,
 
         @Schema(description = "휴가 종류 (예: ANNUAL, SICK, HALF)", example = "ANNUAL")
+        @NotNull(message = "휴가 종류는 필수입니다.")
         LeaveType type,
 
         @Schema(description = "휴가 사유", example = "가족 행사 참석")
+        @Nullable
         String reason
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/leave/dto/request/RejectLeaveRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/dto/request/RejectLeaveRequest.java
@@ -1,9 +1,11 @@
 package com.bmilab.backend.domain.leave.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 public record RejectLeaveRequest(
         @Schema(description = "반려 사유", example = "연가 수 부족")
+        @NotNull(message = "반려 사유는 필수 입력 항목입니다.")
         String rejectReason
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/project/controller/AdminProjectController.java
+++ b/src/main/java/com/bmilab/backend/domain/project/controller/AdminProjectController.java
@@ -4,6 +4,7 @@ import com.bmilab.backend.domain.project.dto.request.ExternalProfessorRequest;
 import com.bmilab.backend.domain.project.dto.response.ExternalProfessorFindAllResponse;
 import com.bmilab.backend.domain.project.service.ProjectService;
 import com.bmilab.backend.global.annotation.OnlyAdmin;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -24,7 +25,7 @@ public class AdminProjectController implements AdminProjectApi{
     private final ProjectService projectService;
 
     @PostMapping("/external-professors")
-    public ResponseEntity<Void> createExternalProfessor(@RequestBody ExternalProfessorRequest request) {
+    public ResponseEntity<Void> createExternalProfessor(@RequestBody @Valid ExternalProfessorRequest request) {
         projectService.createExternalProfessor(request);
 
         return ResponseEntity.ok().build();
@@ -33,7 +34,7 @@ public class AdminProjectController implements AdminProjectApi{
     @PutMapping("/external-professors/{professorId}")
     public ResponseEntity<Void> updateExternalProfessor(
             @PathVariable Long professorId,
-            @RequestBody ExternalProfessorRequest request
+            @RequestBody @Valid ExternalProfessorRequest request
     ) {
         projectService.updateExternalProfessor(professorId, request);
 

--- a/src/main/java/com/bmilab/backend/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/bmilab/backend/domain/project/controller/ProjectController.java
@@ -13,6 +13,7 @@ import com.bmilab.backend.domain.project.enums.ProjectStatus;
 import com.bmilab.backend.domain.project.service.ProjectService;
 import com.bmilab.backend.domain.report.dto.response.ReportFindAllResponse;
 import com.bmilab.backend.global.security.UserAuthInfo;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -32,10 +33,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import java.time.LocalDate;
 import java.util.UUID;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @RestController
 @RequestMapping("/projects")
@@ -47,7 +48,7 @@ public class ProjectController implements ProjectApi {
     @PostMapping
     public ResponseEntity<Void> createNewProject(
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
-            @RequestBody ProjectRequest request
+            @RequestBody @Valid ProjectRequest request
     ) {
 
         projectService.createNewProject(userAuthInfo.getUserId(), request);
@@ -78,7 +79,7 @@ public class ProjectController implements ProjectApi {
     public ResponseEntity<Void> updateProject(
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @PathVariable Long projectId,
-            @RequestBody ProjectRequest request
+            @RequestBody @Valid ProjectRequest request
     ) {
 
         projectService.updateProject(userAuthInfo.getUserId(), projectId, request);
@@ -89,7 +90,7 @@ public class ProjectController implements ProjectApi {
     public ResponseEntity<Void> completeProject(
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @PathVariable Long projectId,
-            @RequestBody ProjectCompleteRequest request
+            @RequestBody @Valid ProjectCompleteRequest request
     ) {
 
         projectService.completeProject(userAuthInfo.getUserId(), projectId, request);

--- a/src/main/java/com/bmilab/backend/domain/project/controller/TimelineController.java
+++ b/src/main/java/com/bmilab/backend/domain/project/controller/TimelineController.java
@@ -4,7 +4,7 @@ import com.bmilab.backend.domain.project.dto.request.TimelineRequest;
 import com.bmilab.backend.domain.project.dto.response.TimelineFindAllResponse;
 import com.bmilab.backend.domain.project.service.TimelineService;
 import com.bmilab.backend.global.security.UserAuthInfo;
-import java.util.UUID;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.UUID;
+
 @RestController
 @RequestMapping("/projects/{projectId}/timelines")
 @RequiredArgsConstructor
@@ -28,7 +30,7 @@ public class TimelineController implements TimelineApi {
     public ResponseEntity<Void> createTimeline(
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @PathVariable Long projectId,
-            @RequestBody TimelineRequest request
+            @RequestBody @Valid TimelineRequest request
     ) {
 
         timelineService.createTimeline(userAuthInfo.getUserId(), projectId, request);
@@ -40,7 +42,7 @@ public class TimelineController implements TimelineApi {
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @PathVariable Long projectId,
             @PathVariable Long timelineId,
-            @RequestBody TimelineRequest request
+            @RequestBody @Valid TimelineRequest request
     ) {
         timelineService.updateTimeline(userAuthInfo.getUserId(), projectId, timelineId, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/bmilab/backend/domain/project/dto/request/ExternalProfessorRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/project/dto/request/ExternalProfessorRequest.java
@@ -1,8 +1,28 @@
 package com.bmilab.backend.domain.project.dto.request;
 
+import com.bmilab.backend.global.validation.RegExp;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
 public record ExternalProfessorRequest(
+
+        @Schema(description = "외부 교수 이름", example = "황선태")
+        @NotBlank(message = "외부 교수 이름은 필수입니다.")
+        @Pattern(regexp = RegExp.NAME_EXPRESSION, message = RegExp.NAME_MESSAGE)
+        @Size(max = 10, message = "이름은 10자 이하로 입력해주세요.")
         String name,
+
+        @Schema(description = "기관", example = "국민대학교")
+        @NotBlank(message = "기관은 필수입니다.")
+        @Size(max = 50, message = "기관명은 50자 이하로 입력해주세요.")
         String organization,
+
+        @Schema(description = "부서", example = "소프트웨어학부")
+        @Nullable
+        @Size(max = 20, message = "부서명은 20자 이하로 입력해주세요.")
         String department
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/project/dto/request/ProjectCompleteRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/project/dto/request/ProjectCompleteRequest.java
@@ -1,10 +1,15 @@
 package com.bmilab.backend.domain.project.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.format.annotation.DateTimeFormat;
+
 import java.time.LocalDate;
 
 public record ProjectCompleteRequest(
         @Schema(description = "연구 종료 날짜", example = "2025-04-25")
+        @NotNull(message = "연구 종료 날짜는 필수입니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
         LocalDate endDate
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/project/dto/request/ProjectRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/project/dto/request/ProjectRequest.java
@@ -2,57 +2,82 @@ package com.bmilab.backend.domain.project.dto.request;
 
 import com.bmilab.backend.domain.project.dto.ExternalProfessorSummary;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.format.annotation.DateTimeFormat;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 public record ProjectRequest(
         @Schema(description = "연구 제목", example = "글로우업 AI 에디터 개발")
+        @NotBlank(message = "연구 제목은 필수입니다.")
         String title,
 
         @Schema(description = "연구 설명", example = "Gemini 기반 AI 텍스트 작성 툴 백엔드 구현")
+        @NotNull(message = "연구 설명은 필수입니다.")
+        @Size(max = 500, message = "연구 설명은 500자 이하로 입력해주세요.")
         String content,
 
         @Schema(description = "연구 책임자의 사용자 ID 리스트", example = "[1, 2]")
+        @NotNull(message = "연구 책임자 ID 리스트는 필수입니다.")
         List<Long> leaderIds,
 
         @Schema(description = "연구 참여자의 사용자 ID 리스트", example = "[3, 4, 5]")
+        @Nullable
         List<Long> participantIds,
 
         @Schema(description = "연구 시작일", example = "2025-05-01")
+        @NotNull(message = "연구 시작일은 필수입니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd") // LocalDate에 맞는 포맷
         LocalDate startDate,
 
         @Schema(description = "연구 종료일 (있으면)", example = "2025-06-30")
+        @Nullable
+        @DateTimeFormat(pattern = "yyyy-MM-dd") // LocalDate에 맞는 포맷
         LocalDate endDate,
 
         @Schema(description = "PI")
+        @Nullable
         List<ExternalProfessorSummary> piList,
 
         @Schema(description = "실무 교수")
+        @Nullable
         List<ExternalProfessorSummary> practicalProfessors,
 
         @Schema(description = "IRB 번호 (있으면)", example = "IRB-DSEB-...")
+        @Nullable
         String irbId,
 
         @Schema(description = "DRB 번호 (있으면)", example = "DRB-DSEB-...")
+        @Nullable
         String drbId,
 
         @Schema(description = "(새로 추가된 파일의 ID만) IRB 파일 ID 리스트", example = "[\"dfaef-afaefaef-aefaefae-...\", \"efaeaf-aefafea-aefaef..\"]")
+        @Nullable
         List<UUID> irbFileIds,
 
         @Schema(description = "(새로 추가된 파일의 ID만) DRB 파일 ID 리스트", example = "[\"dfaef-afaefaef-aefaefae-...\", \"dfaef-afaefaef-aefaefae-...\", \"dfaef-afaefaef-aefaefae-...\"]")
+        @Nullable
         List<UUID> drbFileIds,
 
         @Schema(description  = "(새로 추가된 파일의 ID만) 일반 첨부파일 ID 리스트", example = "[\"dfaef-afaefaef-aefaefae-...\", \"dfaef-afaefaef-aefaefae-..., dfaef-afaefaef-aefaefae-...\"]")
+        @Nullable
         List<UUID> fileIds,
 
         @Schema(description = "대기 상태 여부", example = "false")
+        @NotNull(message = "대기 상태 여부는 필수입니다.")
         boolean isWaiting,
 
         @Schema(description = "연구 분야 아이디", example = "1")
+        @NotNull(message = "연구 분야 ID는 필수입니다.")
         Long categoryId,
 
         @Schema(description = "연구 비공개 여부")
+        @NotNull(message = "연구 비공개 여부는 필수입니다.")
         boolean isPrivate
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/project/dto/request/TimelineRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/project/dto/request/TimelineRequest.java
@@ -2,6 +2,12 @@ package com.bmilab.backend.domain.project.dto.request;
 
 import com.bmilab.backend.domain.project.enums.TimelineType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.format.annotation.DateTimeFormat;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -9,27 +15,41 @@ import java.util.UUID;
 
 public record TimelineRequest(
         @Schema(description = "타임라인 제목", example = "AI 도입 전략 타임라인")
+        @NotBlank(message = "타임라인 제목은 필수입니다.")
+        @Size(max = 30, message = "타임라인 제목은 최대 30자까지 입력 가능합니다.")
         String title,
 
         @Schema(description = "타임라인 날짜", example = "2025-05-10")
+        @NotNull(message = "타임라인 날짜는 필수입니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
         LocalDate date,
 
         @Schema(type = "string", pattern = "HH:mm", example = "14:30")
+        @Nullable
+        @DateTimeFormat(pattern = "HH:mm")
         LocalTime startTime,
-        
+
         @Schema(type = "string", pattern = "HH:mm", example = "14:30")
+        @Nullable
+        @DateTimeFormat(pattern = "HH:mm")
         LocalTime endTime,
 
         @Schema(description = "미팅 장소", example = "7층 회의실 1")
+        @Nullable
+        @Size(max = 30, message = "미팅 장소는 최대 30자까지 입력 가능합니다.")
         String meetingPlace,
 
         @Schema(description = "타임라인 유형 (예: 정기 타임라인, 연구 발표)", example = "정기 타임라인")
+        @NotNull(message = "타임라인 유형은 필수입니다.")
         TimelineType type,
 
         @Schema(description = "타임라인 내용", example = "시장 조사 결과를 바탕으로 AI 기술 도입 로드맵 설정")
+        @NotBlank(message = "타임라인 내용은 필수입니다.")
+        @Size(max = 200, message = "타임라인 내용은 최대 200자까지 입력 가능합니다.")
         String summary,
 
         @Schema(description = "타임라인 첨부파일 ID 목록")
+        @Nullable
         List<UUID> fileIds
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/projectcategory/controller/AdminProjectCategoryController.java
+++ b/src/main/java/com/bmilab/backend/domain/projectcategory/controller/AdminProjectCategoryController.java
@@ -1,14 +1,12 @@
 package com.bmilab.backend.domain.projectcategory.controller;
 
 import com.bmilab.backend.domain.projectcategory.dto.request.ProjectCategoryRequest;
-import com.bmilab.backend.domain.projectcategory.dto.response.ProjectCategoryFindAllResponse;
 import com.bmilab.backend.domain.projectcategory.service.ProjectCategoryService;
 import com.bmilab.backend.global.annotation.OnlyAdmin;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -25,7 +23,7 @@ public class AdminProjectCategoryController implements AdminProjectCategoryApi {
     private final ProjectCategoryService projectCategoryService;
 
     @PostMapping
-    public ResponseEntity<Void> createProjectCategory(@RequestBody ProjectCategoryRequest request) {
+    public ResponseEntity<Void> createProjectCategory(@RequestBody @Valid ProjectCategoryRequest request) {
         projectCategoryService.createProjectCategory(request);
 
         return ResponseEntity.ok().build();
@@ -34,7 +32,7 @@ public class AdminProjectCategoryController implements AdminProjectCategoryApi {
     @PutMapping("/{categoryId}")
     public ResponseEntity<Void> updateProjectCategory(
             @PathVariable Long categoryId,
-            @RequestBody ProjectCategoryRequest request
+            @RequestBody @Valid ProjectCategoryRequest request
     ) {
         projectCategoryService.updateById(categoryId, request);
 

--- a/src/main/java/com/bmilab/backend/domain/projectcategory/dto/request/ProjectCategoryRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/projectcategory/dto/request/ProjectCategoryRequest.java
@@ -1,6 +1,13 @@
 package com.bmilab.backend.domain.projectcategory.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record ProjectCategoryRequest(
+        @Schema(description = "연구 분야 이름", example = "Artificial Intelligence")
+        @NotBlank(message = "연구 분야 이름은 필수입니다.")
+        @Size(max = 30, message = "연구 분야 이름은 30자 이하로 입력해주세요.")
         String name
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/report/controller/ReportController.java
+++ b/src/main/java/com/bmilab/backend/domain/report/controller/ReportController.java
@@ -4,6 +4,7 @@ import com.bmilab.backend.domain.report.dto.request.ReportRequest;
 import com.bmilab.backend.domain.report.dto.response.ReportFindAllResponse;
 import com.bmilab.backend.domain.report.service.ReportService;
 import com.bmilab.backend.global.security.UserAuthInfo;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,7 +30,7 @@ public class ReportController implements ReportApi {
     @PostMapping
     public ResponseEntity<Void> createReport(
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
-            @RequestBody ReportRequest request
+            @RequestBody @Valid ReportRequest request
     ) {
 
         reportService.createReport(userAuthInfo.getUserId(), request);
@@ -40,7 +41,7 @@ public class ReportController implements ReportApi {
     public ResponseEntity<Void> updateReport(
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @PathVariable Long reportId,
-            @RequestBody ReportRequest request
+            @RequestBody @Valid ReportRequest request
     ) {
 
         reportService.updateReport(userAuthInfo.getUserId(), reportId, request);

--- a/src/main/java/com/bmilab/backend/domain/report/dto/request/ReportRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/report/dto/request/ReportRequest.java
@@ -1,13 +1,30 @@
 package com.bmilab.backend.domain.report.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.format.annotation.DateTimeFormat;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 public record ReportRequest(
+        @Schema(description = "프로젝트 아이디", example = "1.0")
+        @NotNull(message = "프로젝트 ID는 필수입니다.")
         Long projectId,
+
+        @Schema(description = "생성 일자", example = "2024-12-07")
+        @NotNull(message = "생성 일자는 필수입니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
         LocalDate date,
+
+        @Schema(description = "업무 내용", example = "팀 회의 참석 후, 프로젝트 진행 상황 점검")
+        @NotNull(message = "업무 내용은 필수입니다.")
         String content,
+
+        @Schema(description  = "일반 첨부파일 ID 리스트", example = "[\"dfaef-afaefaef-aefaefae-...\", \"dfaef-afaefaef-aefaefae-..., dfaef-afaefaef-aefaefae-...\"]")
+        @Nullable
         List<UUID> fileIds
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/user/controller/AdminUserController.java
+++ b/src/main/java/com/bmilab/backend/domain/user/controller/AdminUserController.java
@@ -7,6 +7,7 @@ import com.bmilab.backend.domain.user.dto.response.UserDetail;
 import com.bmilab.backend.domain.user.service.AuthService;
 import com.bmilab.backend.domain.user.service.UserService;
 import com.bmilab.backend.global.annotation.OnlyAdmin;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +29,7 @@ public class AdminUserController implements AdminUserApi {
     private final UserService userService;
 
     @PostMapping
-    public ResponseEntity<Void> registerNewUser(@RequestBody RegisterUserRequest request) {
+    public ResponseEntity<Void> registerNewUser(@RequestBody @Valid RegisterUserRequest request) {
 
         authService.registerNewUser(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -43,7 +44,7 @@ public class AdminUserController implements AdminUserApi {
     @PatchMapping("/{userId}")
     public ResponseEntity<Void> updateUserById(
             @PathVariable Long userId,
-            @RequestBody AdminUpdateUserRequest request
+            @RequestBody @Valid AdminUpdateUserRequest request
     ) {
 
         userService.updateUserById(userId, request);
@@ -60,7 +61,7 @@ public class AdminUserController implements AdminUserApi {
     @PostMapping("/{userId}/account-email")
     public ResponseEntity<Void> sendAccountEmail(
             @PathVariable Long userId,
-            @RequestBody UserAccountEmailRequest request
+            @RequestBody @Valid UserAccountEmailRequest request
     ) {
 
         userService.sendAccountEmail(userId, request);

--- a/src/main/java/com/bmilab/backend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/bmilab/backend/domain/user/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.bmilab.backend.domain.user.controller;
 import com.bmilab.backend.domain.user.dto.request.LoginRequest;
 import com.bmilab.backend.domain.user.dto.response.LoginResponse;
 import com.bmilab.backend.domain.user.service.AuthService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,7 +19,7 @@ public class AuthController implements AuthApi {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+    public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
 
         return ResponseEntity.ok(authService.login(request));
     }

--- a/src/main/java/com/bmilab/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/bmilab/backend/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import com.bmilab.backend.domain.user.dto.response.UserDetail;
 import com.bmilab.backend.domain.user.dto.response.UserFindAllResponse;
 import com.bmilab.backend.domain.user.service.UserService;
 import com.bmilab.backend.global.security.UserAuthInfo;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.MediaType;
@@ -37,7 +38,7 @@ public class UserController implements UserApi {
 
     @PatchMapping("/password")
     public ResponseEntity<Void> sendFindPasswordEmail(
-            @RequestBody FindPasswordEmailRequest request
+            @RequestBody @Valid FindPasswordEmailRequest request
     ) {
 
         userService.sendFindPasswordEmail(request);
@@ -70,7 +71,7 @@ public class UserController implements UserApi {
     public ResponseEntity<Void> updateCurrentUser(
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @RequestPart(required = false) MultipartFile profileImage,
-            @RequestPart UpdateUserRequest request
+            @RequestPart @Valid UpdateUserRequest request
     ) {
 
         userService.updateCurrentUser(userAuthInfo.getUserId(), profileImage, request);
@@ -80,7 +81,7 @@ public class UserController implements UserApi {
     @PatchMapping("/me/password")
     public ResponseEntity<Void> updatePassword(
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
-            @RequestBody UpdateUserPasswordRequest request
+            @RequestBody @Valid UpdateUserPasswordRequest request
     ) {
 
         userService.updatePassword(userAuthInfo.getUserId(), request);
@@ -90,7 +91,7 @@ public class UserController implements UserApi {
     @PatchMapping("/me/educations")
     public ResponseEntity<Void> addEducations(
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
-            @RequestBody UserEducationRequest request
+            @RequestBody @Valid UserEducationRequest request
     ) {
 
         userService.addEducations(userAuthInfo.getUserId(), request);

--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/AdminUpdateUserRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/AdminUpdateUserRequest.java
@@ -2,44 +2,71 @@ package com.bmilab.backend.domain.user.dto.request;
 
 import com.bmilab.backend.domain.user.enums.Role;
 import com.bmilab.backend.domain.user.enums.UserAffiliation;
+import com.bmilab.backend.global.validation.RegExp;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
 import java.util.List;
 
 public record AdminUpdateUserRequest(
-        @Schema(description = "사용자 이름", example = "홍길동")
+        @Schema(description = "사용자명", example = "홍길동")
+        @NotBlank(message = "사용자 이름은 필수입니다.")
+        @Pattern(regexp = RegExp.NAME_EXPRESSION, message = RegExp.NAME_MESSAGE)
+        @Size(max = 10, message = "사용자명은 10자 이하로 입력해주세요.")
         String name,
 
         @Schema(description = "이메일 주소", example = "hong.gildong@example.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Pattern(regexp = RegExp.EMAIL_EXPRESSION, message = RegExp.EMAIL_MESSAGE)
+        @Size(max = 50, message = "이메일은 50자 이하로 입력해주세요.")
         String email,
 
         @Schema(description = "기관", example = "융합의학연구실")
+        @NotBlank(message = "기관은 필수입니다.")
+        @Size(max = 50, message = "기관명은 50자 이하로 입력해주세요.")
         String organization,
 
         @Schema(description = "부서", example = "개발팀")
+        @NotNull(message = "부서는 필수입니다.")
+        @Size(max = 20, message = "부서명은 20자 이하로 입력해주세요.")
         String department,
 
         @Schema(description = "소속 (있으면)", example = "MASTERS_STUDENT")
+        @Nullable
+        @Size(max = 20, message = "소속은 50자 이하로 입력해주세요.")
         UserAffiliation affiliation,
 
         @Schema(description = "권한")
+        @NotBlank(message = "권한은 필수입니다.")
         Role role,
 
         @Schema(description = "추가된 연구 분야 ID 목록", example = "[1, 2, 3]")
+        @Nullable
         List<Long> newCategoryIds,
 
         @Schema(description = "삭제된 연구 분야 ID 목록", example = "[1, 2, 3]")
+        @Nullable
         List<Long> deletedCategoryIds,
 
         @Schema(description = "전화번호", example = "010-5678-1234")
+        @Pattern(regexp = RegExp.PHONE_NUMBER_EXPRESSION, message = RegExp.PHONE_NUMBER_MESSAGE)
         String phoneNumber,
 
         @Schema(description = "좌석 번호", example = "14-07")
+        @Nullable
         String seatNumber,
 
         @Schema(description = "연가 개수", example = "14.0")
+        @Nullable
         Double annualLeaveCount,
 
         @Schema(description = "비고", example = "특이사항 없음")
+        @Nullable
+        @Size(max = 300, message = "비고는 300자 이하로 입력해주세요.")
         String comment
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/FindPasswordEmailRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/FindPasswordEmailRequest.java
@@ -1,6 +1,16 @@
 package com.bmilab.backend.domain.user.dto.request;
 
+import com.bmilab.backend.global.validation.RegExp;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
 public record FindPasswordEmailRequest(
+        @Schema(description = "이메일 주소", example = "hong.gildong@example.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Pattern(regexp = RegExp.EMAIL_EXPRESSION, message = RegExp.EMAIL_MESSAGE)
+        @Size(max = 50, message = "이메일은 50자 이하로 입력해주세요.")
         String email
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/LoginRequest.java
@@ -1,12 +1,21 @@
 package com.bmilab.backend.domain.user.dto.request;
 
+import com.bmilab.backend.global.validation.RegExp;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 public record LoginRequest(
         @Schema(description = "사용자 이메일 주소", example = "user@example.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Pattern(regexp = RegExp.EMAIL_EXPRESSION, message = RegExp.EMAIL_MESSAGE)
+        @Size(max = 50, message = "이메일은 50자 이하로 입력해주세요.")
         String email,
 
         @Schema(description = "사용자 비밀번호", example = "P@ssw0rd123!")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Pattern(regexp = RegExp.PASSWORD_EXPRESSION, message = RegExp.PASSWORD_MESSAGE)
         String password
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/RegisterUserRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/RegisterUserRequest.java
@@ -2,51 +2,82 @@ package com.bmilab.backend.domain.user.dto.request;
 
 import com.bmilab.backend.domain.user.enums.Role;
 import com.bmilab.backend.domain.user.enums.UserAffiliation;
+import com.bmilab.backend.global.validation.RegExp;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.springframework.format.annotation.DateTimeFormat;
+
 import java.time.LocalDate;
 import java.util.List;
 
 public record RegisterUserRequest(
-        @Schema(description = "사용자 이름", example = "홍길동")
+        @Schema(description = "사용자명", example = "홍길동")
+        @NotBlank(message = "사용자명은 필수입니다.")
+        @Pattern(regexp = RegExp.NAME_EXPRESSION, message = RegExp.NAME_MESSAGE)
+        @Size(max = 10, message = "사용자명은 10자 이하로 입력해주세요.")
         String name,
 
         @Schema(description = "이메일 주소", example = "hong.gildong@example.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Pattern(regexp = RegExp.EMAIL_EXPRESSION, message = RegExp.EMAIL_MESSAGE)
+        @Size(max = 50, message = "이메일은 50자 이하로 입력해주세요.")
         String email,
 
         @Schema(description = "비밀번호", example = "SecurePass123!")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Pattern(regexp = RegExp.PASSWORD_EXPRESSION, message = RegExp.PASSWORD_MESSAGE)
         String password,
 
         @Schema(description = "기관", example = "융합의학연구실")
+        @NotBlank(message = "기관은 필수입니다.")
+        @Size(max = 50, message = "기관명은 50자 이하로 입력해주세요.")
         String organization,
 
         @Schema(description = "부서", example = "개발팀")
+        @NotNull(message = "부서는 필수입니다.")
+        @Size(max = 20, message = "부서명은 20자 이하로 입력해주세요.")
         String department,
 
         @Schema(description = "소속 (있으면)", example = "MASTERS_STUDENT")
+        @Nullable
         UserAffiliation affiliation,
 
         @Schema(description = "권한")
+        @NotBlank(message = "권한은 필수입니다.")
         Role role,
 
         @Schema(description = "총 연차 개수", example = "15.0")
+        @Nullable
         Double annualLeaveCount,
 
         @Schema(description = "이미 사용한 연차 개수", example = "3.5")
+        @Nullable
         Double usedLeaveCount,
 
         @Schema(description = "연구 분야 ID 목록")
+        @Nullable
         List<Long> categoryIds,
 
         @Schema(description = "좌석 번호", example = "12-30")
+        @Nullable
         String seatNumber,
 
         @Schema(description = "전화번호", example = "010-1234-5678")
+        @Pattern(regexp = RegExp.PHONE_NUMBER_EXPRESSION, message = RegExp.PHONE_NUMBER_MESSAGE)
         String phoneNumber,
 
         @Schema(description = "학력")
+        @Nullable
+        @Size(max = 30, message = "학력은 30자 이하로 입력해주세요.")
         List<UserEducationRequest> educations,
 
         @Schema(description = "입사일", example = "2025-04-01")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        @NotNull(message = "입사일은 필수입니다.")
         LocalDate joinedAt
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/UpdateUserPasswordRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/UpdateUserPasswordRequest.java
@@ -1,12 +1,19 @@
 package com.bmilab.backend.domain.user.dto.request;
 
+import com.bmilab.backend.global.validation.RegExp;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record UpdateUserPasswordRequest(
         @Schema(description = "현재 비밀번호", example = "OldPass123!")
+        @NotBlank(message = "현재 비밀번호는 필수입니다.")
+        @Pattern(regexp = RegExp.PASSWORD_EXPRESSION, message = RegExp.PASSWORD_MESSAGE)
         String currentPassword,
 
         @Schema(description = "새 비밀번호", example = "NewPass456!")
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        @Pattern(regexp = RegExp.PASSWORD_EXPRESSION, message = RegExp.PASSWORD_MESSAGE)
         String newPassword
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/UpdateUserRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/UpdateUserRequest.java
@@ -1,35 +1,56 @@
 package com.bmilab.backend.domain.user.dto.request;
 
 import com.bmilab.backend.domain.user.enums.UserAffiliation;
+import com.bmilab.backend.global.validation.RegExp;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
 import java.util.List;
 
 public record UpdateUserRequest(
-        @Schema(description = "사용자 이름", example = "홍길동")
+        @Schema(description = "사용자명", example = "홍길동")
+        @NotBlank(message = "사용자명은 필수입니다.")
+        @Pattern(regexp = RegExp.NAME_EXPRESSION, message = RegExp.NAME_MESSAGE)
+        @Size(max = 10, message = "사용자명은 10자 이하로 입력해주세요.")
         String name,
 
         @Schema(description = "이메일 주소", example = "hong.gildong@example.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Pattern(regexp = RegExp.EMAIL_EXPRESSION, message = RegExp.EMAIL_MESSAGE)
+        @Size(max = 50, message = "이메일은 50자 이하로 입력해주세요.")
         String email,
 
         @Schema(description = "기관", example = "융합의학연구실")
+        @NotBlank(message = "기관명은 필수입니다.")
+        @Size(max = 50, message = "기관명은 50자 이하로 입력해주세요.")
         String organization,
 
         @Schema(description = "부서", example = "개발팀")
+        @Nullable
+        @Size(max = 20, message = "부서명은 20자 이하로 입력해주세요.")
         String department,
 
         @Schema(description = "소속 (있으면)", example = "MASTERS_STUDENT")
+        @Nullable
         UserAffiliation affiliation,
 
         @Schema(description = "추가된 연구 분야 ID 목록", example = "[1, 2, 3]")
+        @Nullable
         List<Long> newCategoryIds,
 
         @Schema(description = "삭제된 연구 분야 ID 목록", example = "[1, 2, 3]")
+        @Nullable
         List<Long> deletedCategoryIds,
 
         @Schema(description = "전화번호", example = "010-5678-1234")
+        @Pattern(regexp = RegExp.PHONE_NUMBER_EXPRESSION,  message = RegExp.PHONE_NUMBER_MESSAGE)
         String phoneNumber,
 
         @Schema(description = "좌석 번호", example = "14-07")
+        @Nullable
         String seatNumber
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/UserAccountEmailRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/UserAccountEmailRequest.java
@@ -1,6 +1,12 @@
 package com.bmilab.backend.domain.user.dto.request;
 
+import com.bmilab.backend.global.validation.RegExp;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public record UserAccountEmailRequest(
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Pattern(regexp = RegExp.PASSWORD_EXPRESSION, message = RegExp.PASSWORD_MESSAGE)
         String password
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/UserEducationRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/UserEducationRequest.java
@@ -3,21 +3,32 @@ package com.bmilab.backend.domain.user.dto.request;
 import com.bmilab.backend.domain.user.enums.EnrollmentStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.format.annotation.DateTimeFormat;
+
 import java.time.YearMonth;
 
 public record UserEducationRequest(
         @Schema(description = "학교 또는 교육 과정명", example = "국민대학교 소프트웨어학부")
+        @NotNull(message = "학교 또는 교육 과정명은 필수입니다.")
+        @Size(max = 30, message = "학교 또는 교육 과정명은 30자 이하로 입력해주세요.")
         String title,
 
         @Schema(description = "학적 상태 (재학, 휴학, 졸업)", example = "ENROLLED")
+        @NotNull(message = "학적 상태는 필수입니다.")
         EnrollmentStatus status,
 
         @Schema(type = "string", description = "시작 연월", example = "2020-03")
         @JsonFormat(pattern = "yyyy-MM")
+        @DateTimeFormat(pattern = "yyyy-MM")
+        @NotNull(message = "시작 연월은 필수입니다.")
         YearMonth startYearMonth,
 
         @Schema(type = "string", description = "종료 연월", example = "2024-02")
         @JsonFormat(pattern = "yyyy-MM")
+        @DateTimeFormat(pattern = "yyyy-MM")
+        @NotNull(message = "종료 연월은 필수입니다.")
         YearMonth endYearMonth
 ) {
 }

--- a/src/main/java/com/bmilab/backend/global/email/EmailSender.java
+++ b/src/main/java/com/bmilab/backend/global/email/EmailSender.java
@@ -3,8 +3,6 @@ package com.bmilab.backend.global.email;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
-import java.io.UnsupportedEncodingException;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.mail.MailProperties;
@@ -14,6 +12,9 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.io.UnsupportedEncodingException;
+import java.util.UUID;
 
 @Slf4j
 @Component

--- a/src/main/java/com/bmilab/backend/global/validation/RegExp.java
+++ b/src/main/java/com/bmilab/backend/global/validation/RegExp.java
@@ -1,0 +1,30 @@
+package com.bmilab.backend.global.validation;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RegExp {
+
+    public static final String NAME_EXPRESSION = "^[가-힣]{2,5}$";
+    public static final String NAME_MESSAGE = "올바른 이름이 아닙니다.";
+
+    public static final String EMAIL_EXPRESSION = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+    public static final String EMAIL_MESSAGE = "이메일 형식이 올바르지 않습니다.";
+
+    public static final String PASSWORD_EXPRESSION = "^(?=.*[a-zA-Z])(?=.*\\d).{8,}$";
+    public static final String PASSWORD_MESSAGE = "비밀번호는 8자 이상의 영문자 및 숫자 조합으로 작성해주세요.";
+
+    public static final String PHONE_NUMBER_EXPRESSION = "^(01[016789])-[0-9]{3,4}-[0-9]{4}$";
+    public static final String PHONE_NUMBER_MESSAGE = "올바른 전화번호가 아닙니다.";
+
+    public static final String YYYY_MM_DD_EXPRESSION = "^\\d{4}-\\d{2}-\\d{2}$";
+    public static final String YYYY_MM_DD_MESSAGE = "올바른 날짜가 아닙니다";
+
+    public static final String HH_MM_EXPRESSION = "^([01]?[0-9]|2[0-3]):([0-5]?[0-9])$";
+    public static final String HH_MM_MESSAGE = "올바른 시간이 아닙니다";
+
+    public static final String YYYY_MM_DD_HH_MM_SS_EXPRESSION = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$";
+    public static final String YYYY_MM_DD_HH_MM_SS_MESSAGE = "올바른 날짜와 시간이 아닙니다";
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- #38 

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 이름, 이메일, 비밀번호, 전화번호 등 주요 항목에 대해 RegExp 기반 정규식 검증 로직 적용
- DTO에 유효성 검사 어노테이션 추가 (`@NotNull`, `@NotBlank`, `@Size`, `@Pattern` 등)
- 유효성 검사 실패 시 400 에러와 필드별 오류 메시지 반환 처리


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 비밀번호는 프론트 측으로부터 명확한 유효성 조건을 전달받지 않아, 현재는 정규식 기반으로 ‘영문+숫자 조합, 8자 이상’ 조건만 우선 적용해둔 상태입니다. 추후 특수문자 포함 여부 등 구체적인 기준 확정이 필요합니다.

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
