### PR TITLE
feat: GlobalExceptionHandler에 validation 예외 처리 추가

### DIFF
--- a/src/main/java/com/bmilab/backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/bmilab/backend/global/exception/ErrorResponse.java
@@ -50,7 +50,7 @@ public class ErrorResponse {
         return ErrorResponse
                 .builder()
                 .code(status.name())
-                .message(e.getMessage())
+                .message(e.getMessage() != null ? e.getMessage() : "An unexpected error occurred")
                 .status(status.value())
                 .timestamp(timestamp)
                 .build();

--- a/src/main/java/com/bmilab/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bmilab/backend/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -27,12 +28,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BindException.class)
     public ResponseEntity<ErrorResponse> handleBindException(BindException exception) {
-        HttpStatus status = HttpStatus.BAD_REQUEST;
-        ErrorResponse errorResponse = ErrorResponse.from(exception, status, Instant.now());
+        return handleValidationException(exception);
+    }
 
-        return ResponseEntity
-                .status(status)
-                .body(errorResponse);
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
+        return handleValidationException(exception);
     }
 
     @ExceptionHandler(Exception.class)
@@ -45,6 +46,14 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
                 .status(httpStatus)
+                .body(errorResponse);
+    }
+
+    private ResponseEntity<ErrorResponse> handleValidationException(Exception exception) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        ErrorResponse errorResponse = ErrorResponse.from(exception, status, Instant.now());
+        return ResponseEntity
+                .status(status)
                 .body(errorResponse);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- #45 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- MethodArgumentNotValidException, BindException 처리 핸들러 추가
- validation 실패 시 400 상태 코드로 응답 처리
- DTO에 정의된 validation 메시지를 그대로 응답 본문에 포함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- MethodArgumentNotValidException이 BindException을 상속하고 있음에도 불구하고, Spring MVC는 유효성 검증 실패 시 이 예외를 별도로 던지고, 정확한 타입 매칭을 요구하기 때문에 `@ExceptionHandler(BindException.class)`로는 처리되지 않습니다.
- 따라서 MethodArgumentNotValidException을 명시적으로 핸들링하도록 처리했습니다. 두 예외 모두 공통적인 유효성 검증 실패에 해당하므로, 내부 로직은 handleValidationException() 메서드로 통합했습니다.


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
