### PR TITLE
fix: projectname/position 필터링 조건에 null-safe 처리 추가

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/bmilab/backend/domain/user/repository/UserRepositoryCustomImpl.java
@@ -74,13 +74,12 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
 
         BooleanExpression nameContains = (filterValue == null || filterValue.isBlank()) ? null : user.name.containsIgnoreCase(filterValue);
         BooleanExpression emailContains = (filterValue == null || filterValue.isBlank()) ? null : user.email.containsIgnoreCase(filterValue);
-        BooleanExpression departmentContains = (filterValue == null || filterValue.isBlank()) ? null : user.department.containsIgnoreCase(filterValue);
         BooleanExpression organizationContains = (filterValue == null || filterValue.isBlank()) ? null : user.organization.containsIgnoreCase(filterValue);
-        BooleanExpression positionEquals = (filterValue == null || filterValue.isBlank() || position == null) ?
-                null : user.position.eq(position);
+        BooleanExpression departmentContains = (filterValue == null || filterValue.isBlank()) ? null : user.department.containsIgnoreCase(filterValue);
+        BooleanExpression positionEquals = (filterValue == null || filterValue.isBlank() || position == null) ? null : user.position.eq(position);
         BooleanExpression categoryContains = (filterValue == null || filterValue.isBlank()) ? null : category.name.containsIgnoreCase(filterValue);
-        BooleanExpression seatNumberContains = (filterValue == null || filterValue.isBlank()) ? null : userInfo.seatNumber.containsIgnoreCase(filterValue);
         BooleanExpression phoneNumberContains = (filterValue == null || filterValue.isBlank()) ? null : userInfo.phoneNumber.containsIgnoreCase(filterValue);
+        BooleanExpression seatNumberContains = (filterValue == null || filterValue.isBlank()) ? null : userInfo.seatNumber.containsIgnoreCase(filterValue);
 
         if (filterBy != null && !filterBy.isBlank() &&
                 filterValue != null && !filterValue.isBlank()) {
@@ -88,12 +87,12 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                 conditionBuilder.andAnyOf(
                         nameContains,
                         emailContains,
-                        departmentContains,
                         organizationContains,
+                        departmentContains,
                         positionEquals,
                         categoryContains,
-                        seatNumberContains,
-                        phoneNumberContains
+                        phoneNumberContains,
+                        seatNumberContains
                 );
             } else {
                 switch (filterBy) {
@@ -101,10 +100,10 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                     case "email" -> conditionBuilder.and(emailContains);
                     case "organization" -> conditionBuilder.and(organizationContains);
                     case "department" -> conditionBuilder.and(departmentContains);
-                    case "position" -> conditionBuilder.and(positionEquals);
-                    case "projectname" -> conditionBuilder.and(categoryContains);
-                    case "seatnumber" -> conditionBuilder.and(seatNumberContains);
+                    case "position" -> conditionBuilder.and(user.position.isNotNull().and(positionEquals));
+                    case "projectname" -> conditionBuilder.and(category.name.isNotNull().and(categoryContains));
                     case "phonenumber" -> conditionBuilder.and(phoneNumberContains);
+                    case "seatnumber" -> conditionBuilder.and(seatNumberContains);
                 }
             }
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- #23 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 검색 조건 중 position과 projectname 필터에서 null 값이 존재할 경우, 조건이 제대로 적용되지 않고 필터를 우회하는 문제가 있었습니다.
- 이 문제를 해결하기 위해 `.isNotNull()` 조건을 명시적으로 추가하여, 필터 대상이 아예 null인 경우는 검색 결과에서 제외되도록 처리했습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
