### PR TITLE
fix: 외부교수 등록 시 중복 확인이 제대로 되지 않던 현상 수정

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/project/dto/ExternalProfessorSummary.java
+++ b/src/main/java/com/bmilab/backend/domain/project/dto/ExternalProfessorSummary.java
@@ -1,5 +1,7 @@
 package com.bmilab.backend.domain.project.dto;
 
+import java.util.Objects;
+
 public record ExternalProfessorSummary(
         String name,
         String organization,
@@ -23,5 +25,12 @@ public record ExternalProfessorSummary(
                 split[2],
                 (split[3].isBlank() ? null : split[3])
         );
+    }
+
+    public boolean equals(ExternalProfessorSummary other) {
+        return Objects.equals(name, other.name) &&
+                Objects.equals(organization, other.organization) &&
+                Objects.equals(department, other.department) &&
+                Objects.equals(position, other.position);
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/project/event/listener/ProjectUpdateEventListener.java
+++ b/src/main/java/com/bmilab/backend/domain/project/event/listener/ProjectUpdateEventListener.java
@@ -35,9 +35,11 @@ public class ProjectUpdateEventListener {
 
         List<ExternalProfessorSummary> exists = externalProfessorRepository.findExists(externalProfessors);
 
-        externalProfessors.removeAll(exists);
+        List<ExternalProfessorSummary> nonExists = externalProfessors.stream()
+                .filter(dto -> exists.stream().noneMatch(dto::equals))
+                .toList();
 
-        externalProfessors.stream()
+        nonExists.stream()
                 .map(dto ->
                         ExternalProfessor.builder()
                                 .name(dto.name())


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

외부교수 등록 시에 중복 확인 제대로 되지 않던 현상을 수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
