### PR TITLE
fix: createTask 시 TaskPeriod가 자동 생성되지 않던 문제 수정

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/task/service/TaskService.java
+++ b/src/main/java/com/bmilab/backend/domain/task/service/TaskService.java
@@ -102,6 +102,14 @@ public class TaskService {
                 .build();
 
         taskRepository.save(task);
+
+        for (int i = 1; i <= request.totalYears(); i++) {
+            TaskPeriod period = TaskPeriod.builder()
+                    .task(task)
+                    .yearNumber(i)
+                    .build();
+            taskPeriodRepository.save(period);
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #115 

## 📝작업 내용
- createTask 메서드에서 과제 생성 후 totalYears 수만큼 TaskPeriod를 자동으로 생성하도록 수정합니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
