### PR TITLE
feat: 2주 단위 일일업무보고 미제출 현황 텔레그램 알림 기능 추가

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/report/repository/ReportRepositoryCustom.java
+++ b/src/main/java/com/bmilab/backend/domain/report/repository/ReportRepositoryCustom.java
@@ -25,4 +25,8 @@ public interface ReportRepositoryCustom {
     List<GetAllReportsQueryResult> findAllByDateWithFiles(LocalDate date);
 
     List<GetAllReportsQueryResult> findAllByUser(Long userId);
+
+    List<Long> findProjectIdsWithoutReports(LocalDate startDate, LocalDate endDate);
+
+    List<Long> findUserIdsWithoutReports(LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/bmilab/backend/domain/report/repository/ReportRepositoryCustomImpl.java
+++ b/src/main/java/com/bmilab/backend/domain/report/repository/ReportRepositoryCustomImpl.java
@@ -169,4 +169,31 @@ public class ReportRepositoryCustomImpl implements ReportRepositoryCustom {
             return null;
         }
     }
+
+    @Override
+    public List<Long> findProjectIdsWithoutReports(LocalDate startDate, LocalDate endDate) {
+        QReport report = QReport.report;
+
+        return queryFactory
+                .select(report.project.id)
+                .from(report)
+                .where(
+                        report.project.id.isNotNull(),
+                        report.date.between(startDate, endDate)
+                )
+                .distinct()
+                .fetch();
+    }
+
+    @Override
+    public List<Long> findUserIdsWithoutReports(LocalDate startDate, LocalDate endDate) {
+        QReport report = QReport.report;
+
+        return queryFactory
+                .select(report.user.id)
+                .from(report)
+                .where(report.date.between(startDate, endDate))
+                .distinct()
+                .fetch();
+    }
 }

--- a/src/main/java/com/bmilab/backend/domain/report/service/ReportExportConverter.java
+++ b/src/main/java/com/bmilab/backend/domain/report/service/ReportExportConverter.java
@@ -1,8 +1,10 @@
 package com.bmilab.backend.domain.report.service;
 
 import com.bmilab.backend.domain.file.entity.FileInformation;
+import com.bmilab.backend.domain.project.entity.Project;
 import com.bmilab.backend.domain.report.dto.query.GetAllReportsQueryResult;
 import com.bmilab.backend.domain.report.entity.Report;
+import com.bmilab.backend.domain.user.entity.User;
 import com.bmilab.backend.global.utils.ExcelRow;
 import org.springframework.stereotype.Component;
 
@@ -74,6 +76,39 @@ public class ReportExportConverter {
             sb.append("\n");
 
         }
+        return sb.toString();
+    }
+
+    public String toWeeklyMissingReports(
+            List<Project> projectsWithoutReports,
+            List<User> usersWithoutReports
+    ) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("\\[보고 안된 프로젝트\\]\n");
+        if (projectsWithoutReports.isEmpty()) {
+            sb.append("    \\-    없음\n");
+        } else {
+            for (Project project : projectsWithoutReports) {
+                sb.append("    •    ");
+                sb.append(escMdV2(project.getTitle()));
+                sb.append("\n");
+            }
+        }
+
+        sb.append("\n\\[보고 안한 유저\\]\n");
+        if (usersWithoutReports.isEmpty()) {
+            sb.append("    \\-    없음\n");
+        } else {
+            for (User user : usersWithoutReports) {
+                sb.append("    •    ");
+                sb.append(escMdV2(user.getName()));
+                sb.append(" \\(");
+                sb.append(escMdV2(user.getEmail()));
+                sb.append("\\)\n");
+            }
+        }
+
         return sb.toString();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #126 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- ReportRepositoryCustom/Impl: 기간 내 보고서 작성자 조회 메서드 추가
- ReportExportConverter: 미제출 현황 텔레그램 메시지 포맷팅 메서드 추가
- ReportSchedulerService: 2주 미제출 현황 스케줄러 추가 (텔레그램 전송)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- 우선 테스트를 위해 평일 14시 45분으로 스케줄러를 설정하였습니다.

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
