### PR TITLE
hotfix: LocalDate 역직렬화 설정 제거하여 ISO 8601 형식 지원

### DIFF
--- a/src/main/java/com/bmilab/backend/global/config/JacksonConfig.java
+++ b/src/main/java/com/bmilab/backend/global/config/JacksonConfig.java
@@ -1,7 +1,6 @@
 package com.bmilab.backend.global.config;
 
 import com.bmilab.backend.global.utils.LocalTimeJsonHandler;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
@@ -25,11 +24,9 @@ public class JacksonConfig {
     @Bean
     public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
         return builder -> {
-            // LocalDate 직렬화/역직렬화 (타임존 무시)
+            // LocalDate 직렬화만 설정 (역직렬화는 기본 설정 사용 - ISO 8601 포함 여러 형식 지원)
             builder.serializerByType(LocalDate.class,
                 new LocalDateSerializer(DateTimeFormatter.ofPattern(DATE_FORMAT)));
-            builder.deserializerByType(LocalDate.class,
-                new LocalDateDeserializer(DateTimeFormatter.ofPattern(DATE_FORMAT)));
 
             // LocalDateTime 직렬화/역직렬화 (타임존 무시)
             builder.serializerByType(LocalDateTime.class,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #139 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- LocalDate 역직렬화 설정 제거하여 ISO 8601 형식 지원하도록 수정합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
