### PR TITLE
hotfix: 제안서/발표 탈락, 과제종료 상태 어드민 수정 허용

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/task/controller/TaskController.java
+++ b/src/main/java/com/bmilab/backend/domain/task/controller/TaskController.java
@@ -24,6 +24,7 @@ import com.bmilab.backend.domain.task.dto.response.TaskStatsResponse;
 import com.bmilab.backend.domain.task.dto.response.TaskSummaryResponse;
 import com.bmilab.backend.domain.task.enums.TaskStatus;
 import com.bmilab.backend.domain.task.service.TaskService;
+import com.bmilab.backend.domain.user.enums.Role;
 import com.bmilab.backend.global.security.UserAuthInfo;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -62,7 +63,8 @@ public class TaskController implements TaskApi {
             @PathVariable Long taskId,
             @RequestBody @Valid TaskRequest request
     ) {
-        taskService.updateTask(userAuthInfo.getUserId(), taskId, request);
+        boolean isAdmin = userAuthInfo.getUser().getRole() == Role.ADMIN;
+        taskService.updateTask(userAuthInfo.getUserId(), isAdmin, taskId, request);
         return ResponseEntity.ok().build();
     }
 
@@ -107,7 +109,8 @@ public class TaskController implements TaskApi {
             @PathVariable Long taskId,
             @RequestBody @Valid TaskBasicInfoUpdateRequest request
     ) {
-        taskService.updateBasicInfo(userAuthInfo.getUserId(), taskId, request);
+        boolean isAdmin = userAuthInfo.getUser().getRole() == Role.ADMIN;
+        taskService.updateBasicInfo(userAuthInfo.getUserId(), isAdmin, taskId, request);
         return ResponseEntity.ok().build();
     }
 
@@ -126,7 +129,8 @@ public class TaskController implements TaskApi {
             @PathVariable Long taskId,
             @RequestBody @Valid TaskProposalUpdateRequest request
     ) {
-        taskService.updateProposal(userAuthInfo.getUserId(), taskId, request);
+        boolean isAdmin = userAuthInfo.getUser().getRole() == Role.ADMIN;
+        taskService.updateProposal(userAuthInfo.getUserId(), isAdmin, taskId, request);
         return ResponseEntity.ok().build();
     }
 
@@ -145,7 +149,8 @@ public class TaskController implements TaskApi {
             @PathVariable Long taskId,
             @RequestBody @Valid TaskPresentationUpdateRequest request
     ) {
-        taskService.updatePresentation(userAuthInfo.getUserId(), taskId, request);
+        boolean isAdmin = userAuthInfo.getUser().getRole() == Role.ADMIN;
+        taskService.updatePresentation(userAuthInfo.getUserId(), isAdmin, taskId, request);
         return ResponseEntity.ok().build();
     }
 
@@ -164,7 +169,8 @@ public class TaskController implements TaskApi {
             @PathVariable Long taskId,
             @RequestBody @Valid TaskAgreementUpdateRequest request
     ) {
-        taskService.updateAgreement(userAuthInfo.getUserId(), taskId, request);
+        boolean isAdmin = userAuthInfo.getUser().getRole() == Role.ADMIN;
+        taskService.updateAgreement(userAuthInfo.getUserId(), isAdmin, taskId, request);
         return ResponseEntity.ok().build();
     }
 
@@ -185,7 +191,8 @@ public class TaskController implements TaskApi {
             @PathVariable Long periodId,
             @RequestBody @Valid TaskPeriodUpdateRequest request
     ) {
-        taskService.updateTaskPeriod(userAuthInfo.getUserId(), taskId, periodId, request);
+        boolean isAdmin = userAuthInfo.getUser().getRole() == Role.ADMIN;
+        taskService.updateTaskPeriod(userAuthInfo.getUserId(), isAdmin, taskId, periodId, request);
         return ResponseEntity.ok().build();
     }
 
@@ -194,7 +201,8 @@ public class TaskController implements TaskApi {
             @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @PathVariable Long taskId
     ) {
-        taskService.deleteTask(userAuthInfo.getUserId(), taskId);
+        boolean isAdmin = userAuthInfo.getUser().getRole() == Role.ADMIN;
+        taskService.deleteTask(userAuthInfo.getUserId(), isAdmin, taskId);
         return ResponseEntity.ok().build();
     }
 
@@ -204,7 +212,8 @@ public class TaskController implements TaskApi {
             @PathVariable Long taskId,
             @PathVariable UUID fileId
     ) {
-        taskService.deleteTaskFile(userAuthInfo.getUserId(), taskId, fileId);
+        boolean isAdmin = userAuthInfo.getUser().getRole() == Role.ADMIN;
+        taskService.deleteTaskFile(userAuthInfo.getUserId(), isAdmin, taskId, fileId);
         return ResponseEntity.ok().build();
     }
 
@@ -223,7 +232,8 @@ public class TaskController implements TaskApi {
             @PathVariable Long taskId,
             @RequestBody @Valid AcknowledgementUpdateRequest request
     ) {
-        taskService.saveAcknowledgement(userAuthInfo.getUserId(), taskId, request);
+        boolean isAdmin = userAuthInfo.getUser().getRole() == Role.ADMIN;
+        taskService.saveAcknowledgement(userAuthInfo.getUserId(), isAdmin, taskId, request);
         return ResponseEntity.ok().build();
     }
 
@@ -251,7 +261,8 @@ public class TaskController implements TaskApi {
             @PathVariable Long taskId,
             @RequestBody @Valid PublicationUpdateRequest request
     ) {
-        taskService.savePublication(userAuthInfo.getUserId(), taskId, request);
+        boolean isAdmin = userAuthInfo.getUser().getRole() == Role.ADMIN;
+        taskService.savePublication(userAuthInfo.getUserId(), isAdmin, taskId, request);
         return ResponseEntity.ok().build();
     }
 
@@ -270,7 +281,8 @@ public class TaskController implements TaskApi {
             @PathVariable Long taskId,
             @RequestBody @Valid ConferenceRequest request
     ) {
-        taskService.saveConference(userAuthInfo.getUserId(), taskId, request);
+        boolean isAdmin = userAuthInfo.getUser().getRole() == Role.ADMIN;
+        taskService.saveConference(userAuthInfo.getUserId(), isAdmin, taskId, request);
         return ResponseEntity.ok().build();
     }
 
@@ -289,7 +301,8 @@ public class TaskController implements TaskApi {
             @PathVariable Long taskId,
             @RequestBody @Valid PatentRequest request
     ) {
-        taskService.savePatent(userAuthInfo.getUserId(), taskId, request);
+        boolean isAdmin = userAuthInfo.getUser().getRole() == Role.ADMIN;
+        taskService.savePatent(userAuthInfo.getUserId(), isAdmin, taskId, request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/bmilab/backend/domain/task/entity/Task.java
+++ b/src/main/java/com/bmilab/backend/domain/task/entity/Task.java
@@ -142,13 +142,15 @@ public class Task extends BaseTimeEntity {
         this.participatingInstitutions = participatingInstitutions;
     }
 
-    public boolean canBeEditedByUser(Long userId) {
+    // 제안서 탈락, 발표 탈락, 과제 종료 상태에서는 실무책임자 또는 어드민만 수정 가능
+    public boolean canBeEditedByUser(Long userId, boolean isAdmin) {
         if (this.status != TaskStatus.PROPOSAL_REJECTED
                 && this.status != TaskStatus.PRESENTATION_REJECTED
                 && this.status != TaskStatus.COMPLETED) {
             return true;
         }
 
-        return this.practicalManager != null && this.practicalManager.getId().equals(userId);
+        // 어드민이거나 실무책임자인 경우 수정 가능
+        return isAdmin || (this.practicalManager != null && this.practicalManager.getId().equals(userId));
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/task/service/TaskService.java
+++ b/src/main/java/com/bmilab/backend/domain/task/service/TaskService.java
@@ -141,11 +141,11 @@ public class TaskService {
     }
 
     @Transactional
-    public void updateTask(Long userId, Long taskId, TaskRequest request) {
+    public void updateTask(Long userId, boolean isAdmin, Long taskId, TaskRequest request) {
 
         Task task = getTaskById(taskId);
 
-        if (!task.canBeEditedByUser(userId)) {
+        if (!task.canBeEditedByUser(userId, isAdmin)) {
             throw new ApiException(TaskErrorCode.TASK_CANNOT_EDIT);
         }
 
@@ -294,11 +294,11 @@ public class TaskService {
     }
 
     @Transactional
-    public void updateBasicInfo(Long userId, Long taskId, TaskBasicInfoUpdateRequest request) {
+    public void updateBasicInfo(Long userId, boolean isAdmin, Long taskId, TaskBasicInfoUpdateRequest request) {
 
         Task task = getTaskById(taskId);
 
-        if (!task.canBeEditedByUser(userId)) {
+        if (!task.canBeEditedByUser(userId, isAdmin)) {
             throw new ApiException(TaskErrorCode.TASK_CANNOT_EDIT);
         }
 
@@ -348,11 +348,11 @@ public class TaskService {
     }
 
     @Transactional
-    public void updateProposal(Long userId, Long taskId, TaskProposalUpdateRequest request) {
+    public void updateProposal(Long userId, boolean isAdmin, Long taskId, TaskProposalUpdateRequest request) {
 
         Task task = getTaskById(taskId);
 
-        if (!task.canBeEditedByUser(userId)) {
+        if (!task.canBeEditedByUser(userId, isAdmin)) {
             throw new ApiException(TaskErrorCode.TASK_CANNOT_EDIT);
         }
 
@@ -485,11 +485,11 @@ public class TaskService {
     }
 
     @Transactional
-    public void updatePresentation(Long userId, Long taskId, TaskPresentationUpdateRequest request) {
+    public void updatePresentation(Long userId, boolean isAdmin, Long taskId, TaskPresentationUpdateRequest request) {
 
         Task task = getTaskById(taskId);
 
-        if (!task.canBeEditedByUser(userId)) {
+        if (!task.canBeEditedByUser(userId, isAdmin)) {
             throw new ApiException(TaskErrorCode.TASK_CANNOT_EDIT);
         }
 
@@ -549,11 +549,11 @@ public class TaskService {
     }
 
     @Transactional
-    public void updateAgreement(Long userId, Long taskId, TaskAgreementUpdateRequest request) {
+    public void updateAgreement(Long userId, boolean isAdmin, Long taskId, TaskAgreementUpdateRequest request) {
 
         Task task = getTaskById(taskId);
 
-        if (!task.canBeEditedByUser(userId)) {
+        if (!task.canBeEditedByUser(userId, isAdmin)) {
             throw new ApiException(TaskErrorCode.TASK_CANNOT_EDIT);
         }
 
@@ -594,11 +594,11 @@ public class TaskService {
     }
 
     @Transactional
-    public void updateTaskPeriod(Long userId, Long taskId, Long periodId, TaskPeriodUpdateRequest request) {
+    public void updateTaskPeriod(Long userId, boolean isAdmin, Long taskId, Long periodId, TaskPeriodUpdateRequest request) {
 
         Task task = getTaskById(taskId);
 
-        if (!task.canBeEditedByUser(userId)) {
+        if (!task.canBeEditedByUser(userId, isAdmin)) {
             throw new ApiException(TaskErrorCode.TASK_CANNOT_EDIT);
         }
 
@@ -621,11 +621,11 @@ public class TaskService {
     }
 
     @Transactional
-    public void deleteTask(Long userId, Long taskId) {
+    public void deleteTask(Long userId, boolean isAdmin, Long taskId) {
 
         Task task = getTaskById(taskId);
 
-        if (!task.canBeEditedByUser(userId)) {
+        if (!task.canBeEditedByUser(userId, isAdmin)) {
             throw new ApiException(TaskErrorCode.TASK_CANNOT_EDIT);
         }
 
@@ -633,11 +633,11 @@ public class TaskService {
     }
 
     @Transactional
-    public void deleteTaskFile(Long userId, Long taskId, java.util.UUID fileId) {
+    public void deleteTaskFile(Long userId, boolean isAdmin, Long taskId, java.util.UUID fileId) {
 
         Task task = getTaskById(taskId);
 
-        if (!task.canBeEditedByUser(userId)) {
+        if (!task.canBeEditedByUser(userId, isAdmin)) {
             throw new ApiException(TaskErrorCode.TASK_CANNOT_EDIT);
         }
 
@@ -653,11 +653,11 @@ public class TaskService {
     }
 
     @Transactional
-    public void saveAcknowledgement(Long userId, Long taskId, AcknowledgementUpdateRequest request) {
+    public void saveAcknowledgement(Long userId, boolean isAdmin, Long taskId, AcknowledgementUpdateRequest request) {
 
         Task task = getTaskById(taskId);
 
-        if (!task.canBeEditedByUser(userId)) {
+        if (!task.canBeEditedByUser(userId, isAdmin)) {
             throw new ApiException(TaskErrorCode.TASK_CANNOT_EDIT);
         }
 
@@ -686,11 +686,11 @@ public class TaskService {
     }
 
     @Transactional
-    public void savePublication(Long userId, Long taskId, PublicationUpdateRequest request) {
+    public void savePublication(Long userId, boolean isAdmin, Long taskId, PublicationUpdateRequest request) {
 
         Task task = getTaskById(taskId);
 
-        if (!task.canBeEditedByUser(userId)) {
+        if (!task.canBeEditedByUser(userId, isAdmin)) {
             throw new ApiException(TaskErrorCode.TASK_CANNOT_EDIT);
         }
 
@@ -717,11 +717,11 @@ public class TaskService {
     }
 
     @Transactional
-    public void saveConference(Long userId, Long taskId, ConferenceRequest request) {
+    public void saveConference(Long userId, boolean isAdmin, Long taskId, ConferenceRequest request) {
 
         Task task = getTaskById(taskId);
 
-        if (!task.canBeEditedByUser(userId)) {
+        if (!task.canBeEditedByUser(userId, isAdmin)) {
             throw new ApiException(TaskErrorCode.TASK_CANNOT_EDIT);
         }
 
@@ -747,11 +747,11 @@ public class TaskService {
     }
 
     @Transactional
-    public void savePatent(Long userId, Long taskId, PatentRequest request) {
+    public void savePatent(Long userId, boolean isAdmin, Long taskId, PatentRequest request) {
 
         Task task = getTaskById(taskId);
 
-        if (!task.canBeEditedByUser(userId)) {
+        if (!task.canBeEditedByUser(userId, isAdmin)) {
             throw new ApiException(TaskErrorCode.TASK_CANNOT_EDIT);
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #144 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
-  canBeEditedByUser 메서드에 isAdmin 파라미터 추가
- TaskService의 수정/삭제 관련 12개 메서드 시그니처 변경 및 권한 체크 로직 적용

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
